### PR TITLE
Add query parameter to autofill long link

### DIFF
--- a/frontend/src/component/form/TextField.tsx
+++ b/frontend/src/component/form/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Component } from 'react';
+import React, { ChangeEvent, Component, createRef } from 'react';
 import './TextField.scss';
 
 interface Props {
@@ -13,6 +13,8 @@ interface State {
 }
 
 export class TextField extends Component<Props, State> {
+  textInput = createRef<HTMLInputElement>();
+
   handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!this.props.onChange) {
       return;
@@ -27,9 +29,14 @@ export class TextField extends Component<Props, State> {
     this.props.onBlur();
   };
 
+  focus = () => {
+    this.textInput.current!.focus();
+  };
+
   render = () => {
     return (
       <input
+        ref={this.textInput}
         className={'text-field'}
         type={'text'}
         value={this.props.text}

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -70,7 +70,19 @@ export class Home extends Component<Props, State> {
       this.showSignInModal();
       return;
     }
+    this.handleStateChange();
+    this.autoFillLongLink();
+  }
 
+  autoFillLongLink() {
+    const longLink = this.getLongLinkFromQueryParams();
+    if (validateLongLinkFormat(longLink) == null) {
+      this.props.store.dispatch(updateLongLink(longLink));
+      this.shortLinkTextField.current!.focus();
+    }
+  }
+
+  handleStateChange() {
     this.props.store.subscribe(async () => {
       const state = this.props.store.getState();
 
@@ -94,15 +106,6 @@ export class Home extends Component<Props, State> {
       }
       this.setState(newState);
     });
-    this.autoFillLongLink();
-  }
-
-  autoFillLongLink() {
-    const longLink = this.getLongLinkFromQueryParams();
-    if (validateLongLinkFormat(longLink) == null) {
-      this.props.store.dispatch(updateLongLink(longLink));
-      this.shortLinkTextField.current!.focus();
-    }
   }
 
   showSignInModal() {

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -57,6 +57,7 @@ interface State {
 export class Home extends Component<Props, State> {
   errModal = React.createRef<Modal>();
   signInModal = React.createRef<SignInModal>();
+  shortLinkTextField = React.createRef<TextField>();
 
   constructor(props: Props) {
     super(props);
@@ -93,6 +94,15 @@ export class Home extends Component<Props, State> {
       }
       this.setState(newState);
     });
+    this.autoFillLongLink();
+  }
+
+  autoFillLongLink() {
+    const longLink = this.getLongLinkFromQueryParams();
+    if (validateLongLinkFormat(longLink) == null) {
+      this.props.store.dispatch(updateLongLink(longLink));
+      this.shortLinkTextField.current!.focus();
+    }
   }
 
   showSignInModal() {
@@ -150,6 +160,11 @@ export class Home extends Component<Props, State> {
       });
   };
 
+  getLongLinkFromQueryParams(): string {
+    let urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('long_link')!;
+  }
+
   showError(error?: IErr) {
     if (!error) {
       return;
@@ -175,6 +190,7 @@ export class Home extends Component<Props, State> {
               </div>
               <div className={'text-field-wrapper'}>
                 <TextField
+                  ref={this.shortLinkTextField}
                   text={this.state.alias}
                   placeHolder={'Custom Short Link ( Optional )'}
                   onBlur={this.handlerCustomAliasTextFieldBlur}


### PR DESCRIPTION
resolves https://github.com/short-d/short/issues/205

## New Behavior
### Description
Automatically fill in long link when `long_link` query parameter exists. The cursor will automatically focused on alias text field, waiting for the user to provide a custom alias.

### Screenshots
<img width="1413" alt="Screen Shot 2020-01-19 at 8 33 37 PM" src="https://user-images.githubusercontent.com/13726179/72698924-19aa1280-3afb-11ea-9b3b-d3257536a085.png">