### PR TITLE
Refactor account for Facebook OAuth

### DIFF
--- a/backend/app/adapter/facebook/account_integration_test.go
+++ b/backend/app/adapter/facebook/account_integration_test.go
@@ -1,0 +1,91 @@
+package facebook
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/short-d/app/mdtest"
+	"github.com/short-d/short/app/entity"
+)
+
+func TestAccount_GetSingleSignOnUser(t *testing.T) {
+	testCases := []struct {
+		name            string
+		httpResponse    *http.Response
+		httpErr         error
+		expectHasErr    bool
+		expectedSSOUser entity.SSOUser
+	}{
+		{
+			name:         "invalid access token",
+			httpResponse: nil,
+			httpErr:      errors.New("invalid access token"),
+			expectHasErr: true,
+		},
+		{
+			name: "user has email and name",
+			httpResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
+{
+      "name": "Facebook User",
+      "email": "facebookUser@gmail.com"
+}
+`,
+				)))},
+			expectHasErr: false,
+			expectedSSOUser: entity.SSOUser{
+				Name:  "Facebook User",
+				Email: "facebookUser@gmail.com",
+			},
+		},
+		{
+			name: "user doesn't have email",
+			httpResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
+{
+      "name": "Facebook User",
+      "email": ""
+}
+`,
+				)))},
+			expectHasErr: false,
+			expectedSSOUser: entity.SSOUser{
+				Name:  "Facebook User",
+				Email: "",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			httpRequest := mdtest.NewHTTPRequestFake(
+				func(req *http.Request) (response *http.Response, e error) {
+					mdtest.Equal(t, "https", req.URL.Scheme)
+					mdtest.Equal(t, "graph.facebook.com", req.URL.Host)
+					mdtest.Equal(t, "/me", req.URL.Path)
+					mdtest.Equal(t, "access_token", req.URL.Query().Get("access_token"))
+					mdtest.Equal(t, "name,email", req.URL.Query().Get("fields"))
+					mdtest.Equal(t, "GET", req.Method)
+
+					return testCase.httpResponse, testCase.httpErr
+				})
+			facebookAccount := NewAccount(httpRequest)
+
+			gotSSOUser, err := facebookAccount.GetSingleSignOnUser("access_token")
+
+			if testCase.expectHasErr {
+				mdtest.NotEqual(t, nil, err)
+				return
+			}
+			mdtest.Equal(t, nil, err)
+			mdtest.Equal(t, testCase.expectedSSOUser, gotSSOUser)
+		})
+	}
+}

--- a/backend/app/adapter/facebook/account_integration_test.go
+++ b/backend/app/adapter/facebook/account_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration all
+
 package facebook
 
 import (

--- a/backend/dep/wire_gen.go
+++ b/backend/dep/wire_gen.go
@@ -109,7 +109,7 @@ func InjectRoutingService(name string, prefix provider.LogPrefix, logLevel fw.Lo
 	githubAccount := github.NewAccount(graphQL)
 	api := github.NewAPI(identityProvider, githubAccount)
 	facebookIdentityProvider := provider.NewFacebookIdentityProvider(http, facebookClientID, facebookClientSecret, facebookRedirectURI)
-	facebookAccount := facebook.NewAccount()
+	facebookAccount := facebook.NewAccount(http)
 	facebookAPI := facebook.NewAPI(facebookIdentityProvider, facebookAccount)
 	googleIdentityProvider := provider.NewGoogleIdentityProvider(http, googleClientID, googleClientSecret, googleRedirectURI)
 	googleAccount := google.NewAccount(http)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/google/wire v0.4.0
-	github.com/huandu/facebook v2.3.1+incompatible
 	github.com/short-d/app v0.0.0-20200108075430-a7a081c61daf
 	github.com/short-d/kgs v0.0.0-20200105183048-3be4c3acc728
 	google.golang.org/grpc v1.26.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -47,8 +47,6 @@ github.com/graph-gophers/graphql-go v0.0.0-20190902214650-641ae197eec7 h1:91UwqV
 github.com/graph-gophers/graphql-go v0.0.0-20190902214650-641ae197eec7/go.mod h1:Au3iQ8DvDis8hZ4q2OzRcaKYlAsPt+fYvib5q4nIqu4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/huandu/facebook v2.3.1+incompatible h1:+F6kUqKx5TifzMg2fXYZFdA/3VVNphdNK8G4PF2ui74=
-github.com/huandu/facebook v2.3.1+incompatible/go.mod h1:wJogp9rhXUUjDuhx6ZaR5Eylx3dsJmy0zyFRaPYUq5g=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -92,10 +90,6 @@ github.com/sendgrid/sendgrid-go v3.5.0+incompatible h1:kosbgHyNVYVaqECDYvFVLVD9n
 github.com/sendgrid/sendgrid-go v3.5.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/short-d/app v0.0.0-20200105164223-e5615740ec60 h1:sLUDNbokAgSrfIZc0B6VvYcq0UhecHsy/zaJQKxwTeM=
 github.com/short-d/app v0.0.0-20200105164223-e5615740ec60/go.mod h1:L3bsuFXGyUFKU05c73y7w2BaksvIIIzQR2hB1cpvJ1g=
-github.com/short-d/app v0.0.0-20200105224216-bfaee9df6800 h1:lZ/pLr3tOmqHuNIl/DiUtmGE9KFJzfP0zk13Pdd+myI=
-github.com/short-d/app v0.0.0-20200105224216-bfaee9df6800/go.mod h1:L3bsuFXGyUFKU05c73y7w2BaksvIIIzQR2hB1cpvJ1g=
-github.com/short-d/app v0.0.0-20200108071827-304a2038ed5b h1:6IXtOtDyeNjhsBACDUC9YuB9IPeTOetZeTQbEIbFTfY=
-github.com/short-d/app v0.0.0-20200108071827-304a2038ed5b/go.mod h1:L3bsuFXGyUFKU05c73y7w2BaksvIIIzQR2hB1cpvJ1g=
 github.com/short-d/app v0.0.0-20200108075430-a7a081c61daf h1:Xf04Hkv6iDy4eFjSx2CaZ/OlApxyJY/tP2wf7+MIonM=
 github.com/short-d/app v0.0.0-20200108075430-a7a081c61daf/go.mod h1:L3bsuFXGyUFKU05c73y7w2BaksvIIIzQR2hB1cpvJ1g=
 github.com/short-d/eventbus v0.0.0-20200105092235-2dfc4be1f9ee h1:LNafZ4caEAcTlgGe9zJ18njsyR+uogkE5+dzZ5LeeAI=
@@ -112,8 +106,6 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## New Behavior
Refactor account module for Facebook OAuth.

Previously, we use a 3rd party package for Facebook Graph API. However, importing the whole package just for retrieving user account information seems unnecessary. This pull request provides a better way of sending http GET request to facebook API to retrieve user information without using 3rd party package.
