### PR TITLE
Refactor IdentityProvider for Facebook OAuth

### DIFF
--- a/backend/app/adapter/facebook/identityprovider.go
+++ b/backend/app/adapter/facebook/identityprovider.go
@@ -52,6 +52,12 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 // RequestAccessToken retrieves access token of user's Facebook account using
 // authorization code.
 func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessToken string, err error) {
+	type fbAccessTokenResponse struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+
 	clientID := g.clientID
 	clientSecret := g.clientSecret
 	redirectURI := g.redirectURI
@@ -86,12 +92,6 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessTo
 	}
 
 	return apiRes.AccessToken, nil
-}
-
-type fbAccessTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
 }
 
 // NewIdentityProvider initializes Facebook OAuth service.

--- a/backend/app/adapter/facebook/identityprovider.go
+++ b/backend/app/adapter/facebook/identityprovider.go
@@ -17,12 +17,6 @@ const (
 	fbResponseType     = "code"
 )
 
-type fbAccessTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-}
-
 var _ service.IdentityProvider = (*IdentityProvider)(nil)
 
 // IdentityProvider represents Facebook OAuth service.
@@ -74,16 +68,30 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessTo
 	query.Set("code", authorizationCode)
 	u.RawQuery = query.Encode()
 
-	headers := map[string]string{}
+	body := url.Values{}
+	body.Set("client_id", clientID)
+	body.Set("redirect_uri", redirectURI)
+	body.Set("client_secret", clientSecret)
+	body.Set("code", authorizationCode)
+
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
 
 	apiRes := fbAccessTokenResponse{}
-	err = g.http.JSON(http.MethodGet, u.String(), headers, "", &apiRes)
+	err = g.http.JSON(http.MethodPost, u.String(), headers, body.Encode(), &apiRes)
 
 	if err != nil {
 		return "", err
 	}
 
 	return apiRes.AccessToken, nil
+}
+
+type fbAccessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
 }
 
 // NewIdentityProvider initializes Facebook OAuth service.

--- a/backend/app/adapter/facebook/identityprovider_integration_test.go
+++ b/backend/app/adapter/facebook/identityprovider_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/short-d/app/mdtest"
@@ -31,7 +32,7 @@ func TestIdentityProvider_GetAuthorizationURL(t *testing.T) {
 	mdtest.Equal(t, "https", parsedUrl.Scheme)
 	mdtest.Equal(t, "www.facebook.com", parsedUrl.Host)
 	mdtest.Equal(t, "/v4.0/dialog/oauth", parsedUrl.Path)
-	mdtest.Equal(t, "public_profile,email", parsedUrl.Query().Get("scope"))
+	mdtest.SameElements(t, [2]string{"public_profile", "email"}, strings.Split(parsedUrl.Query().Get("scope"), ","))
 	mdtest.Equal(t, "code", parsedUrl.Query().Get("response_type"))
 	mdtest.Equal(t, clientID, parsedUrl.Query().Get("client_id"))
 	mdtest.Equal(t, redirectURI, parsedUrl.Query().Get("redirect_uri"))
@@ -108,7 +109,7 @@ func TestIdentityProvider_RequestAccessToken(t *testing.T) {
 			httpErr:             nil,
 			clientID:            "id_12345",
 			clientSecret:        "client_secret",
-			redirectURI:         "http://localhost/oauth/google/sign-in/callback",
+			redirectURI:         "http://localhost/oauth/facebook/sign-in/callback",
 			authorizationCode:   "authorizationCode_1",
 			expectHasErr:        false,
 			expectedAccessToken: "bcBi3AMeOV3Zg3AlOPyn",
@@ -135,7 +136,6 @@ func TestIdentityProvider_RequestAccessToken(t *testing.T) {
 					return testCase.httpResponse, testCase.httpErr
 				})
 			identityProvider := NewIdentityProvider(httpRequest, testCase.clientID, testCase.clientSecret, testCase.redirectURI)
-
 			actualAccessToken, err := identityProvider.RequestAccessToken(testCase.authorizationCode)
 
 			if testCase.expectHasErr {

--- a/backend/app/adapter/facebook/identityprovider_integration_test.go
+++ b/backend/app/adapter/facebook/identityprovider_integration_test.go
@@ -28,14 +28,18 @@ func TestIdentityProvider_GetAuthorizationURL(t *testing.T) {
 	urlResponse := identityProvider.GetAuthorizationURL()
 
 	parsedUrl, err := url.Parse(urlResponse)
+
 	mdtest.Equal(t, nil, err)
 	mdtest.Equal(t, "https", parsedUrl.Scheme)
 	mdtest.Equal(t, "www.facebook.com", parsedUrl.Host)
 	mdtest.Equal(t, "/v4.0/dialog/oauth", parsedUrl.Path)
-	mdtest.SameElements(t, [2]string{"public_profile", "email"}, strings.Split(parsedUrl.Query().Get("scope"), ","))
 	mdtest.Equal(t, "code", parsedUrl.Query().Get("response_type"))
 	mdtest.Equal(t, clientID, parsedUrl.Query().Get("client_id"))
 	mdtest.Equal(t, redirectURI, parsedUrl.Query().Get("redirect_uri"))
+
+	expectedScope := []string{"public_profile", "email"}
+	actualScope := strings.Split(parsedUrl.Query().Get("scope"), ",")
+	mdtest.SameElements(t, expectedScope, actualScope)
 }
 
 func TestIdentityProvider_RequestAccessToken(t *testing.T) {

--- a/backend/app/adapter/facebook/identityprovider_integration_test.go
+++ b/backend/app/adapter/facebook/identityprovider_integration_test.go
@@ -100,9 +100,9 @@ func TestIdentityProvider_RequestAccessToken(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
 {
-      "access_token": "bcBi3AMeOV3Zg3AlOPyn",
-      "token_type": "bearer",
-	  "expires_in": 5183944
+	"access_token": "bcBi3AMeOV3Zg3AlOPyn",
+	"token_type": "bearer",
+	"expires_in": 5183944
 }
 `,
 				)))},

--- a/backend/app/adapter/facebook/identityprovider_integration_test.go
+++ b/backend/app/adapter/facebook/identityprovider_integration_test.go
@@ -1,0 +1,149 @@
+// +build integration all
+
+package facebook
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/short-d/app/mdtest"
+)
+
+func TestIdentityProvider_GetAuthorizationURL(t *testing.T) {
+	t.Parallel()
+	httpRequest := mdtest.NewHTTPRequestFake(
+		func(req *http.Request) (response *http.Response, e error) {
+			return nil, nil
+		})
+	clientID := "id_12345"
+	clientSecret := "client_secret"
+	redirectURI := "http://localhost/oauth/facebook/sign-in/callback"
+	identityProvider := NewIdentityProvider(httpRequest, clientID, clientSecret, redirectURI)
+
+	urlResponse := identityProvider.GetAuthorizationURL()
+
+	parsedUrl, err := url.Parse(urlResponse)
+	mdtest.Equal(t, nil, err)
+	mdtest.Equal(t, "https", parsedUrl.Scheme)
+	mdtest.Equal(t, "www.facebook.com", parsedUrl.Host)
+	mdtest.Equal(t, "/v4.0/dialog/oauth", parsedUrl.Path)
+	mdtest.Equal(t, "public_profile,email", parsedUrl.Query().Get("scope"))
+	mdtest.Equal(t, "code", parsedUrl.Query().Get("response_type"))
+	mdtest.Equal(t, clientID, parsedUrl.Query().Get("client_id"))
+	mdtest.Equal(t, redirectURI, parsedUrl.Query().Get("redirect_uri"))
+}
+
+func TestIdentityProvider_RequestAccessToken(t *testing.T) {
+	testCases := []struct {
+		name                string
+		httpResponse        *http.Response
+		httpErr             error
+		clientID            string
+		clientSecret        string
+		redirectURI         string
+		authorizationCode   string
+		expectHasErr        bool
+		expectedAccessToken string
+	}{
+		{
+			name:                "invalid authorization code",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid authorization code"),
+			clientID:            "id_12345",
+			clientSecret:        "client_secret",
+			redirectURI:         "http://localhost/oauth/facebook/sign-in/callback",
+			authorizationCode:   "invalidCode",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name:                "invalid clientID",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid clientID"),
+			clientID:            "invalidID",
+			clientSecret:        "client_secret",
+			redirectURI:         "http://localhost/oauth/facebook/sign-in/callback",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name:                "invalid client secret",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid clientSecret"),
+			clientID:            "id_12345",
+			clientSecret:        "invalidSecret",
+			redirectURI:         "http://localhost/oauth/facebook/sign-in/callback",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name:                "invalid redirect URI",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid redirectURI"),
+			clientID:            "id_12345",
+			clientSecret:        "client_secret",
+			redirectURI:         "http://localhost/invalidRedirectURI",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name: "success",
+			httpResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
+{
+      "access_token": "bcBi3AMeOV3Zg3AlOPyn",
+      "token_type": "bearer",
+	  "expires_in": 5183944
+}
+`,
+				)))},
+			httpErr:             nil,
+			clientID:            "id_12345",
+			clientSecret:        "client_secret",
+			redirectURI:         "http://localhost/oauth/google/sign-in/callback",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        false,
+			expectedAccessToken: "bcBi3AMeOV3Zg3AlOPyn",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			httpRequest := mdtest.NewHTTPRequestFake(
+				func(req *http.Request) (response *http.Response, e error) {
+					mdtest.Equal(t, "https", req.URL.Scheme)
+					mdtest.Equal(t, "graph.facebook.com", req.URL.Host)
+					mdtest.Equal(t, "/v4.0/oauth/access_token", req.URL.Path)
+					mdtest.Equal(t, testCase.clientID, req.URL.Query().Get("client_id"))
+					mdtest.Equal(t, testCase.clientSecret, req.URL.Query().Get("client_secret"))
+					mdtest.Equal(t, testCase.authorizationCode, req.URL.Query().Get("code"))
+					mdtest.Equal(t, testCase.redirectURI, req.URL.Query().Get("redirect_uri"))
+					mdtest.Equal(t, "POST", req.Method)
+					mdtest.Equal(t, "application/json", req.Header.Get("Accept"))
+					mdtest.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+
+					return testCase.httpResponse, testCase.httpErr
+				})
+			identityProvider := NewIdentityProvider(httpRequest, testCase.clientID, testCase.clientSecret, testCase.redirectURI)
+
+			actualAccessToken, err := identityProvider.RequestAccessToken(testCase.authorizationCode)
+
+			if testCase.expectHasErr {
+				mdtest.NotEqual(t, nil, err)
+				return
+			}
+			mdtest.Equal(t, nil, err)
+			mdtest.Equal(t, testCase.expectedAccessToken, actualAccessToken)
+		})
+	}
+}

--- a/backend/app/adapter/github/identityprovider_integration_test.go
+++ b/backend/app/adapter/github/identityprovider_integration_test.go
@@ -1,0 +1,128 @@
+// +build integration all
+
+package github
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/short-d/app/mdtest"
+)
+
+func TestIdentityProvider_GetAuthorizationURL(t *testing.T) {
+	t.Parallel()
+	httpRequest := mdtest.NewHTTPRequestFake(
+		func(req *http.Request) (response *http.Response, e error) {
+			return nil, nil
+		})
+	clientID := "id_12345"
+	clientSecret := "client_secret"
+	identityProvider := NewIdentityProvider(httpRequest, clientID, clientSecret)
+
+	urlResponse := identityProvider.GetAuthorizationURL()
+
+	parsedUrl, err := url.Parse(urlResponse)
+	fmt.Println(parsedUrl)
+	mdtest.Equal(t, nil, err)
+	mdtest.Equal(t, "https", parsedUrl.Scheme)
+	mdtest.Equal(t, "github.com", parsedUrl.Host)
+	mdtest.Equal(t, "/login/oauth/authorize", parsedUrl.Path)
+	mdtest.Equal(t, clientID, parsedUrl.Query().Get("client_id"))
+	mdtest.Equal(t, "read:user", parsedUrl.Query().Get("scope"))
+}
+
+func TestIdentityProvider_RequestAccessToken(t *testing.T) {
+	testCases := []struct {
+		name                string
+		httpResponse        *http.Response
+		httpErr             error
+		clientID            string
+		clientSecret        string
+		authorizationCode   string
+		expectHasErr        bool
+		expectedAccessToken string
+	}{
+		{
+			name:                "invalid authorization code",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid authorization code"),
+			clientID:            "id_12345",
+			clientSecret:        "client_secret",
+			authorizationCode:   "invalidCode",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name:                "invalid clientID",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid clientID"),
+			clientID:            "invalidID",
+			clientSecret:        "client_secret",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name:                "invalid client secret",
+			httpResponse:        nil,
+			httpErr:             errors.New("invalid clientSecret"),
+			clientID:            "id_12345",
+			clientSecret:        "invalidSecret",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        true,
+			expectedAccessToken: "",
+		},
+		{
+			name: "success",
+			httpResponse: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
+{
+      "access_token": "bcBi3AMeOV3Zg3AlOPyn",
+      "scope": "read:user",
+      "token_type": "bearer"
+}
+`,
+				)))},
+			httpErr:             nil,
+			clientID:            "id_12345",
+			clientSecret:        "client_secret",
+			authorizationCode:   "authorizationCode_1",
+			expectHasErr:        false,
+			expectedAccessToken: "bcBi3AMeOV3Zg3AlOPyn",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			httpRequest := mdtest.NewHTTPRequestFake(
+				func(req *http.Request) (response *http.Response, e error) {
+					mdtest.Equal(t, "https", req.URL.Scheme)
+					mdtest.Equal(t, "github.com", req.URL.Host)
+					mdtest.Equal(t, "/login/oauth/access_token", req.URL.Path)
+					mdtest.Equal(t, "POST", req.Method)
+					mdtest.Equal(t, "application/json", req.Header.Get("Accept"))
+					mdtest.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
+
+					return testCase.httpResponse, testCase.httpErr
+				})
+			identityProvider := NewIdentityProvider(httpRequest, testCase.clientID, testCase.clientSecret)
+
+			actualAccessToken, err := identityProvider.RequestAccessToken(testCase.authorizationCode)
+
+			if testCase.expectHasErr {
+				mdtest.NotEqual(t, nil, err)
+				return
+			}
+			mdtest.Equal(t, nil, err)
+			mdtest.Equal(t, testCase.expectedAccessToken, actualAccessToken)
+		})
+	}
+}


### PR DESCRIPTION
## New Behavior
Refactor IdentityProvider for Facebook OAuth.

Currently our implementation for facebook identityprovider is not well written. By sending http POST  instead of http GET request, we ensure the http request is safer. 