### PR TITLE
Fix empty email bug

### DIFF
--- a/backend/app/usecase/auth/authenticator.go
+++ b/backend/app/usecase/auth/authenticator.go
@@ -17,6 +17,9 @@ type Authenticator struct {
 
 func (a Authenticator) isTokenValid(payload Payload, validDuring time.Duration) bool {
 	now := a.timer.Now()
+	if payload.email == "" {
+		return false
+	}
 	tokenExpireAt := payload.issuedAt.Add(validDuring)
 	return !tokenExpireAt.Before(now)
 }

--- a/backend/app/usecase/auth/authenticator_test.go
+++ b/backend/app/usecase/auth/authenticator_test.go
@@ -62,6 +62,17 @@ func TestAuthenticator_IsSignedIn(t *testing.T) {
 			expIsSignIn: false,
 		},
 		{
+			name:               "Token payload has empty email",
+			expIssuedAt:        now,
+			tokenValidDuration: time.Hour,
+			currentTime:        now.Add(30 * time.Minute),
+			tokenPayload: map[string]interface{}{
+				"email":     "",
+				"issued_at": now.Format(time.RFC3339Nano),
+			},
+			expIsSignIn: false,
+		},
+		{
 			name:               "Token payload without issue_at",
 			expIssuedAt:        now,
 			tokenValidDuration: time.Hour,


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Authenticator treats auth token as valid even though it has empty email.

## New Behavior
### Description
Authenticator treats auth token as invalid when it has empty email.
