### PR TITLE
Move request Facebook sign in to use case

### DIFF
--- a/backend/app/usecase/usecase.go
+++ b/backend/app/usecase/usecase.go
@@ -8,15 +8,21 @@ import (
 
 // UseCase represents all the business logic for Short.
 type UseCase struct {
-	logger           fw.Logger
-	timer            fw.Timer
-	authenticator    auth.Authenticator
-	githubIDProvider service.IdentityProvider
+	logger             fw.Logger
+	timer              fw.Timer
+	authenticator      auth.Authenticator
+	githubIDProvider   service.IdentityProvider
+	facebookIDProvider service.IdentityProvider
 }
 
 // RequestGithubSignIn directs user to Github sign in screen.
 func (u UseCase) RequestGithubSignIn(authToken string, presenter Presenter) {
 	u.requestSSOSignIn(authToken, u.githubIDProvider, presenter)
+}
+
+// RequestFacebookSignIn directs user to Facebook sign in screen.
+func (u UseCase) RequestFacebookSignIn(authToken string, presenter Presenter) {
+	u.requestSSOSignIn(authToken, u.facebookIDProvider, presenter)
 }
 
 func (u UseCase) requestSSOSignIn(
@@ -35,17 +41,22 @@ func (u UseCase) requestSSOSignIn(
 // GithubIDProvider provides Github authentication service.
 type GithubIDProvider service.IdentityProvider
 
+// FacebookIDProvider provides Facebook authentication service.
+type FacebookIDProvider service.IdentityProvider
+
 // NewUseCase creates UseCase.
 func NewUseCase(
 	logger fw.Logger,
 	timer fw.Timer,
 	authenticator auth.Authenticator,
 	githubIDProvider GithubIDProvider,
+	facebookIDProvider FacebookIDProvider,
 ) UseCase {
 	return UseCase{
-		logger:           logger,
-		timer:            timer,
-		authenticator:    authenticator,
-		githubIDProvider: githubIDProvider,
+		logger:             logger,
+		timer:              timer,
+		authenticator:      authenticator,
+		githubIDProvider:   githubIDProvider,
+		facebookIDProvider: facebookIDProvider,
 	}
 }

--- a/backend/app/usecase/usecase_test.go
+++ b/backend/app/usecase/usecase_test.go
@@ -161,9 +161,146 @@ func TestShort_RequestGithubSignIn(t *testing.T) {
 				testCase.now,
 				testCase.tokenValidDuration,
 				testCase.githubIDProvider,
+				stubIDProvider{},
 			)
 			presenter := newMockPresenter()
 			useCase.RequestGithubSignIn(testCase.authToken, &presenter)
+
+			mdtest.Equal(t, testCase.expectedShowHomeCallArgs, presenter.showHomeCallArgs)
+			mdtest.Equal(t, testCase.expectedShowUserHomeCallArgs, presenter.showUserHomeCallArgs)
+			mdtest.Equal(t, testCase.expectedShowExternalPageCallArgs, presenter.showExternalPageCallArgs)
+		})
+	}
+}
+
+func TestShort_RequestFacebookSignIn(t *testing.T) {
+	now, err := time.Parse(time.RFC3339, "2020-01-26T08:32:40.759788656Z")
+	mdtest.Equal(t, nil, err)
+
+	testCases := []struct {
+		name                             string
+		now                              time.Time
+		existingURLs                     map[string]entity.URL
+		existingUsers                    []entity.User
+		oauthURL                         string
+		facebookIDProvider               stubIDProvider
+		authToken                        string
+		tokenValidDuration               time.Duration
+		expectedShowHomeCallArgs         []showHomeCallArgs
+		expectedShowUserHomeCallArgs     []showUserHomeCallArgs
+		expectedShowExternalPageCallArgs []showExternalPageCallArgs
+	}{
+		{
+			name: "user already signed in",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "facebook_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken:                    "auth_token",
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "facebook_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "user has not signed in",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "facebook_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken:                    "",
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "facebook_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token has no email",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "facebook_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "issued_at": "2020-01-26T08:32:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "facebook_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token has empty email",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "facebook_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "email": "",
+  "issued_at": "2020-01-26T08:32:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "facebook_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token expired",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "facebook_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "email": "byliuyang11@gmail.com",
+  "issued_at": "2020-01-26T07:31:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "facebook_sign_in_link",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			useCase := newUseCase(
+				testCase.now,
+				testCase.tokenValidDuration,
+				stubIDProvider{},
+				testCase.facebookIDProvider,
+			)
+			presenter := newMockPresenter()
+			useCase.RequestFacebookSignIn(testCase.authToken, &presenter)
 
 			mdtest.Equal(t, testCase.expectedShowHomeCallArgs, presenter.showHomeCallArgs)
 			mdtest.Equal(t, testCase.expectedShowUserHomeCallArgs, presenter.showUserHomeCallArgs)
@@ -176,6 +313,7 @@ func newUseCase(
 	now time.Time,
 	tokenValidDuration time.Duration,
 	githubIDProvider GithubIDProvider,
+	facebookIDProvider FacebookIDProvider,
 ) UseCase {
 	logger := mdtest.NewLoggerFake(mdtest.FakeLoggerArgs{})
 	timer := mdtest.NewTimerFake(now)
@@ -187,6 +325,7 @@ func newUseCase(
 		timer,
 		authenticator,
 		githubIDProvider,
+		facebookIDProvider,
 	)
 	return useCase
 }


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Github sign in redirection logic is invoking HTTP APIs directly inside [routing](https://github.com/short-d/short/blob/master/backend/app/adapter/routing/handle.go#L57-L65) package. This prevents the sign in logic from being reused for non-HTTP views. It also significantly increased the complexity of `routing` package as more routes being added.

## New Behavior
### Description
Facebook sign in redirection logic is moved into `usecase` package. Interactions with views are abstracted out through `Presenter` interface.