### PR TITLE
Move request Google sign in to Usecase

### DIFF
--- a/backend/app/usecase/usecase.go
+++ b/backend/app/usecase/usecase.go
@@ -13,7 +13,7 @@ type UseCase struct {
 	authenticator      auth.Authenticator
 	githubIDProvider   service.IdentityProvider
 	facebookIDProvider service.IdentityProvider
-	googleIDProvider GoogleIDProvider
+	googleIDProvider   GoogleIDProvider
 }
 
 // RequestGithubSignIn directs user to Github sign in screen.
@@ -68,6 +68,6 @@ func NewUseCase(
 		authenticator:      authenticator,
 		githubIDProvider:   githubIDProvider,
 		facebookIDProvider: facebookIDProvider,
-		googleIDProvider: googleIDProvider,
+		googleIDProvider:   googleIDProvider,
 	}
 }

--- a/backend/app/usecase/usecase.go
+++ b/backend/app/usecase/usecase.go
@@ -28,7 +28,7 @@ func (u UseCase) RequestFacebookSignIn(authToken string, presenter Presenter) {
 
 // RequestGoogleSignIn directs user to Google sign in screen.
 func (u UseCase) RequestGoogleSignIn(authToken string, presenter Presenter) {
-	u.requestSSOSignIn(authToken, u.facebookIDProvider, presenter)
+	u.requestSSOSignIn(authToken, u.googleIDProvider, presenter)
 }
 
 func (u UseCase) requestSSOSignIn(

--- a/backend/app/usecase/usecase.go
+++ b/backend/app/usecase/usecase.go
@@ -13,6 +13,7 @@ type UseCase struct {
 	authenticator      auth.Authenticator
 	githubIDProvider   service.IdentityProvider
 	facebookIDProvider service.IdentityProvider
+	googleIDProvider GoogleIDProvider
 }
 
 // RequestGithubSignIn directs user to Github sign in screen.
@@ -22,6 +23,11 @@ func (u UseCase) RequestGithubSignIn(authToken string, presenter Presenter) {
 
 // RequestFacebookSignIn directs user to Facebook sign in screen.
 func (u UseCase) RequestFacebookSignIn(authToken string, presenter Presenter) {
+	u.requestSSOSignIn(authToken, u.facebookIDProvider, presenter)
+}
+
+// RequestGoogleSignIn directs user to Google sign in screen.
+func (u UseCase) RequestGoogleSignIn(authToken string, presenter Presenter) {
 	u.requestSSOSignIn(authToken, u.facebookIDProvider, presenter)
 }
 
@@ -44,6 +50,9 @@ type GithubIDProvider service.IdentityProvider
 // FacebookIDProvider provides Facebook authentication service.
 type FacebookIDProvider service.IdentityProvider
 
+// GoogleIDProvider provides Google authentication service.
+type GoogleIDProvider service.IdentityProvider
+
 // NewUseCase creates UseCase.
 func NewUseCase(
 	logger fw.Logger,
@@ -51,6 +60,7 @@ func NewUseCase(
 	authenticator auth.Authenticator,
 	githubIDProvider GithubIDProvider,
 	facebookIDProvider FacebookIDProvider,
+	googleIDProvider GoogleIDProvider,
 ) UseCase {
 	return UseCase{
 		logger:             logger,
@@ -58,5 +68,6 @@ func NewUseCase(
 		authenticator:      authenticator,
 		githubIDProvider:   githubIDProvider,
 		facebookIDProvider: facebookIDProvider,
+		googleIDProvider: googleIDProvider,
 	}
 }

--- a/backend/app/usecase/usecase_test.go
+++ b/backend/app/usecase/usecase_test.go
@@ -162,6 +162,7 @@ func TestShort_RequestGithubSignIn(t *testing.T) {
 				testCase.tokenValidDuration,
 				testCase.githubIDProvider,
 				stubIDProvider{},
+				stubIDProvider{},
 			)
 			presenter := newMockPresenter()
 			useCase.RequestGithubSignIn(testCase.authToken, &presenter)
@@ -298,9 +299,147 @@ func TestShort_RequestFacebookSignIn(t *testing.T) {
 				testCase.tokenValidDuration,
 				stubIDProvider{},
 				testCase.facebookIDProvider,
+				stubIDProvider{},
 			)
 			presenter := newMockPresenter()
 			useCase.RequestFacebookSignIn(testCase.authToken, &presenter)
+
+			mdtest.Equal(t, testCase.expectedShowHomeCallArgs, presenter.showHomeCallArgs)
+			mdtest.Equal(t, testCase.expectedShowUserHomeCallArgs, presenter.showUserHomeCallArgs)
+			mdtest.Equal(t, testCase.expectedShowExternalPageCallArgs, presenter.showExternalPageCallArgs)
+		})
+	}
+}
+
+func TestShort_RequestGoogleSignIn(t *testing.T) {
+	now, err := time.Parse(time.RFC3339, "2020-01-26T08:32:40.759788656Z")
+	mdtest.Equal(t, nil, err)
+
+	testCases := []struct {
+		name                             string
+		now                              time.Time
+		existingURLs                     map[string]entity.URL
+		existingUsers                    []entity.User
+		oauthURL                         string
+		facebookIDProvider               stubIDProvider
+		authToken                        string
+		tokenValidDuration               time.Duration
+		expectedShowHomeCallArgs         []showHomeCallArgs
+		expectedShowUserHomeCallArgs     []showUserHomeCallArgs
+		expectedShowExternalPageCallArgs []showExternalPageCallArgs
+	}{
+		{
+			name: "user already signed in",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "google_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken:                    "auth_token",
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "google_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "user has not signed in",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "google_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken:                    "",
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "google_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token has no email",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "google_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "issued_at": "2020-01-26T08:32:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "google_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token has empty email",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "google_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "email": "",
+  "issued_at": "2020-01-26T08:32:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "google_sign_in_link",
+				},
+			},
+		},
+		{
+			name: "auth token expired",
+			now:  now,
+			facebookIDProvider: stubIDProvider{
+				authorizationURL: "google_sign_in_link",
+				accessToken:      "access_token",
+			},
+			authToken: `
+{
+  "email": "byliuyang11@gmail.com",
+  "issued_at": "2020-01-26T07:31:40.759788656Z"
+}
+`,
+			tokenValidDuration:           time.Hour,
+			expectedShowHomeCallArgs:     []showHomeCallArgs{},
+			expectedShowUserHomeCallArgs: []showUserHomeCallArgs{},
+			expectedShowExternalPageCallArgs: []showExternalPageCallArgs{
+				{
+					link: "google_sign_in_link",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			useCase := newUseCase(
+				testCase.now,
+				testCase.tokenValidDuration,
+				stubIDProvider{},
+				testCase.facebookIDProvider,
+				stubIDProvider{},
+			)
+			presenter := newMockPresenter()
+			useCase.RequestGoogleSignIn(testCase.authToken, &presenter)
 
 			mdtest.Equal(t, testCase.expectedShowHomeCallArgs, presenter.showHomeCallArgs)
 			mdtest.Equal(t, testCase.expectedShowUserHomeCallArgs, presenter.showUserHomeCallArgs)
@@ -314,6 +453,7 @@ func newUseCase(
 	tokenValidDuration time.Duration,
 	githubIDProvider GithubIDProvider,
 	facebookIDProvider FacebookIDProvider,
+	googleIDProvider GoogleIDProvider,
 ) UseCase {
 	logger := mdtest.NewLoggerFake(mdtest.FakeLoggerArgs{})
 	timer := mdtest.NewTimerFake(now)
@@ -326,6 +466,7 @@ func newUseCase(
 		authenticator,
 		githubIDProvider,
 		facebookIDProvider,
+		googleIDProvider,
 	)
 	return useCase
 }

--- a/backend/app/usecase/usecase_test.go
+++ b/backend/app/usecase/usecase_test.go
@@ -321,7 +321,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		existingURLs                     map[string]entity.URL
 		existingUsers                    []entity.User
 		oauthURL                         string
-		facebookIDProvider               stubIDProvider
+		googleIDProvider                 stubIDProvider
 		authToken                        string
 		tokenValidDuration               time.Duration
 		expectedShowHomeCallArgs         []showHomeCallArgs
@@ -331,7 +331,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		{
 			name: "user already signed in",
 			now:  now,
-			facebookIDProvider: stubIDProvider{
+			googleIDProvider: stubIDProvider{
 				authorizationURL: "google_sign_in_link",
 				accessToken:      "access_token",
 			},
@@ -348,7 +348,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		{
 			name: "user has not signed in",
 			now:  now,
-			facebookIDProvider: stubIDProvider{
+			googleIDProvider: stubIDProvider{
 				authorizationURL: "google_sign_in_link",
 				accessToken:      "access_token",
 			},
@@ -365,7 +365,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		{
 			name: "auth token has no email",
 			now:  now,
-			facebookIDProvider: stubIDProvider{
+			googleIDProvider: stubIDProvider{
 				authorizationURL: "google_sign_in_link",
 				accessToken:      "access_token",
 			},
@@ -386,7 +386,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		{
 			name: "auth token has empty email",
 			now:  now,
-			facebookIDProvider: stubIDProvider{
+			googleIDProvider: stubIDProvider{
 				authorizationURL: "google_sign_in_link",
 				accessToken:      "access_token",
 			},
@@ -408,7 +408,7 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 		{
 			name: "auth token expired",
 			now:  now,
-			facebookIDProvider: stubIDProvider{
+			googleIDProvider: stubIDProvider{
 				authorizationURL: "google_sign_in_link",
 				accessToken:      "access_token",
 			},
@@ -435,8 +435,8 @@ func TestShort_RequestGoogleSignIn(t *testing.T) {
 				testCase.now,
 				testCase.tokenValidDuration,
 				stubIDProvider{},
-				testCase.facebookIDProvider,
 				stubIDProvider{},
+				testCase.googleIDProvider,
 			)
 			presenter := newMockPresenter()
 			useCase.RequestGoogleSignIn(testCase.authToken, &presenter)


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Github sign in redirection logic is invoking HTTP APIs directly inside [routing](https://github.com/short-d/short/blob/master/backend/app/adapter/routing/handle.go#L57-L65) package. This prevents the sign in logic from being reused for non-HTTP views. It also significantly increased the complexity of `routing` package as more routes being added.

## New Behavior
### Description
Google sign in redirection logic is moved into `usecase` package. Interactions with views are abstracted out through `Presenter` interface.