### PR TITLE
Fix the missed dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "material-design-icons": "^3.0.1",
     "qrcode": "^1.4.2",
     "react": "^16.10.2",
+    "react-debounce-input": "^3.2.2",
     "react-dom": "^16.10.2",
     "react-router-dom": "^5.1.2",
     "recaptcha-v3": "^1.7.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6745,6 +6745,11 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.debounce@^4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -9150,6 +9155,14 @@ react-app-polyfill@^1.0.4:
     raf "3.4.1"
     regenerator-runtime "0.13.3"
     whatwg-fetch "3.0.0"
+
+react-debounce-input@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-debounce-input/-/react-debounce-input-3.2.2.tgz#d2cc99c1ce47fae89037965f5699edc1b0317197"
+  integrity sha512-RIBu68Cq/gImKz/2h1cE042REDqyqj3D+7SJ3lnnIpJX0ht9D9PfH7KAnL+SgDz6hvKa9pZS2CnAxlkrLmnQlg==
+  dependencies:
+    lodash.debounce "^4"
+    prop-types "^15.7.2"
 
 react-dev-utils@^9.1.0:
   version "9.1.0"


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
`react-debounce-input` is missing from `package.json`. This breaks our frontend build.

### Screenshots
<img width="690" alt="Screen Shot 2020-03-06 at 7 51 58 PM" src="https://user-images.githubusercontent.com/3537801/76136209-00462280-5fe4-11ea-843b-6c0d40c72075.png">

## New Behavior
### Description
`react-debounce-input` is added to `package.json`.
