### PR TITLE
draft for search RESTful API

### DIFF
--- a/backend/app/adapter/db/url.go
+++ b/backend/app/adapter/db/url.go
@@ -96,6 +96,21 @@ WHERE "%s"=$1;`,
 	return url, nil
 }
 
+// GetByAliases finds URLs for a list of aliases
+func (u URLSql) GetByAliases(aliases []string) ([]entity.URL, error) {
+	urls := make([]entity.URL, 0)
+
+	for _, alias := range aliases {
+		url, err := u.GetByAlias(alias)
+
+		if err != nil {
+			return urls, err
+		}
+		urls = append(urls, url)
+	}
+	return urls, nil
+}
+
 // NewURLSql creates URLSql
 func NewURLSql(db *sql.DB) *URLSql {
 	return &URLSql{

--- a/backend/app/adapter/routing/handle.go
+++ b/backend/app/adapter/routing/handle.go
@@ -1,8 +1,11 @@
 package routing
 
 import (
+	"encoding/json"
 	"net/http"
 	netURL "net/url"
+
+	"github.com/short-d/short/app/usecase/search"
 
 	"github.com/short-d/app/fw"
 	"github.com/short-d/short/app/usecase/auth"
@@ -83,5 +86,34 @@ func NewSSOSignInCallback(
 
 		webFrontendURL = setToken(webFrontendURL, authToken)
 		http.Redirect(w, r, webFrontendURL.String(), http.StatusSeeOther)
+	}
+}
+
+// NewSearchAPI fetches user's public short links and private short links
+func NewSearchAPI(
+	logger fw.Logger,
+	tracer fw.Tracer,
+	search search.Search,
+	authenticator auth.Authenticator,
+) fw.Handle {
+	return func(w http.ResponseWriter, r *http.Request, params fw.Params) {
+		token := getToken(params)
+		user, err := authenticator.GetUser(token)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		urls, err := search.SearchForURLs(user)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		err = json.NewEncoder(w).Encode(urls)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/backend/app/adapter/routing/route.go
+++ b/backend/app/adapter/routing/route.go
@@ -3,6 +3,8 @@ package routing
 import (
 	netURL "net/url"
 
+	"github.com/short-d/short/app/usecase/search"
+
 	"github.com/short-d/app/fw"
 	"github.com/short-d/short/app/adapter/facebook"
 	"github.com/short-d/short/app/adapter/github"
@@ -31,6 +33,7 @@ func NewShort(
 	googleAPI google.API,
 	authenticator auth.Authenticator,
 	accountProvider account.Provider,
+	search search.Search,
 ) []fw.Route {
 	githubSignIn := sso.NewSingleSignOn(
 		githubAPI.IdentityProvider,
@@ -129,6 +132,16 @@ func NewShort(
 				urlRetriever,
 				timer,
 				*frontendURL,
+			),
+		},
+		{
+			Method: "GET",
+			Path:   "/api/search",
+			Handle: NewSearchAPI(
+				logger,
+				tracer,
+				search,
+				authenticator,
 			),
 		},
 	}

--- a/backend/app/usecase/account/linker_test.go
+++ b/backend/app/usecase/account/linker_test.go
@@ -5,11 +5,11 @@ package account
 import (
 	"testing"
 
-	"github.com/short-d/short/app/usecase/service"
 	"github.com/short-d/app/mdtest"
 	"github.com/short-d/short/app/entity"
 	"github.com/short-d/short/app/usecase/keygen"
 	"github.com/short-d/short/app/usecase/repository"
+	"github.com/short-d/short/app/usecase/service"
 )
 
 func TestLinker_IsAccountLinked(t *testing.T) {

--- a/backend/app/usecase/repository/url.go
+++ b/backend/app/usecase/repository/url.go
@@ -7,4 +7,5 @@ type URL interface {
 	IsAliasExist(alias string) (bool, error)
 	GetByAlias(alias string) (entity.URL, error)
 	Create(url entity.URL) error
+	GetByAliases(aliases []string) ([]entity.URL, error)
 }

--- a/backend/app/usecase/repository/url_fake.go
+++ b/backend/app/usecase/repository/url_fake.go
@@ -45,6 +45,11 @@ func (u URLFake) GetByAlias(alias string) (entity.URL, error) {
 	return url, nil
 }
 
+// GetByAliases finds all URL for a list of aliases
+func (u URLFake) GetByAliases(aliases []string) ([]entity.URL, error) {
+	return nil, nil
+}
+
 // NewURLFake creates in memory URL repository
 func NewURLFake(urls map[string]entity.URL) URLFake {
 	return URLFake{

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -1,0 +1,26 @@
+package search
+
+import (
+	"github.com/short-d/short/app/entity"
+	"github.com/short-d/short/app/usecase/repository"
+)
+
+type Search struct {
+	userUrlRepo repository.UserURLRelation
+	urlRepo     repository.URL
+}
+
+// SearchForURLs fetches all URLs for a given user
+func (s Search) SearchForURLs(user entity.User) ([]entity.URL, error) {
+	aliases, err := s.userUrlRepo.FindAliasesByUser(user)
+	if err != nil {
+		return nil, err
+	}
+
+	urls, err := s.urlRepo.GetByAliases(aliases)
+	if err != nil {
+		return nil, err
+	}
+
+	return urls, nil
+}

--- a/backend/app/usecase/search/search_test.go
+++ b/backend/app/usecase/search/search_test.go
@@ -1,0 +1,9 @@
+package search
+
+import (
+	"testing"
+)
+
+func TestSearch_SearchForURLs(t *testing.T) {
+	t.Parallel()
+}


### PR DESCRIPTION
## New Behavior
### Description
Added RESTful API for search functionality.

User should be able to search the public and the private short links they created. In order to support that, we add RESTful API to search for all urls created by a given user.