### PR TITLE
Support retrieving user ID from Facebook account

### DIFF
--- a/backend/app/adapter/facebook/account.go
+++ b/backend/app/adapter/facebook/account.go
@@ -21,6 +21,7 @@ type Account struct {
 // GetSingleSignOnUser retrieves user's email and name from Facebook API.
 func (g Account) GetSingleSignOnUser(accessToken string) (entity.SSOUser, error) {
 	type response struct {
+		ID    string `json:"id"`
 		Email string `json:"email"`
 		Name  string `json:"name"`
 	}
@@ -33,7 +34,7 @@ func (g Account) GetSingleSignOnUser(accessToken string) (entity.SSOUser, error)
 	}
 
 	query := u.Query()
-	query.Set("fields", "name,email")
+	query.Set("fields", "id,name,email")
 	query.Set("access_token", accessToken)
 	u.RawQuery = query.Encode()
 
@@ -46,6 +47,7 @@ func (g Account) GetSingleSignOnUser(accessToken string) (entity.SSOUser, error)
 	}
 
 	return entity.SSOUser{
+		ID:    fbResponse.ID,
 		Email: fbResponse.Email,
 		Name:  fbResponse.Name,
 	}, nil

--- a/backend/app/adapter/facebook/account_integration_test.go
+++ b/backend/app/adapter/facebook/account_integration_test.go
@@ -28,11 +28,12 @@ func TestAccount_GetSingleSignOnUser(t *testing.T) {
 			expectHasErr: true,
 		},
 		{
-			name: "user has email and name",
+			name: "user has id, email and name",
 			httpResponse: &http.Response{
 				StatusCode: http.StatusOK,
 				Body: ioutil.NopCloser(bytes.NewReader([]byte(`
 {
+      "id": "12321321312312",
       "name": "Facebook User",
       "email": "facebookUser@gmail.com"
 }
@@ -40,6 +41,7 @@ func TestAccount_GetSingleSignOnUser(t *testing.T) {
 				)))},
 			expectHasErr: false,
 			expectedSSOUser: entity.SSOUser{
+				ID:    "12321321312312",
 				Name:  "Facebook User",
 				Email: "facebookUser@gmail.com",
 			},
@@ -73,7 +75,7 @@ func TestAccount_GetSingleSignOnUser(t *testing.T) {
 					mdtest.Equal(t, "graph.facebook.com", req.URL.Host)
 					mdtest.Equal(t, "/me", req.URL.Path)
 					mdtest.Equal(t, "access_token", req.URL.Query().Get("access_token"))
-					mdtest.Equal(t, "name,email", req.URL.Query().Get("fields"))
+					mdtest.Equal(t, "id,name,email", req.URL.Query().Get("fields"))
 					mdtest.Equal(t, "GET", req.Method)
 
 					return testCase.httpResponse, testCase.httpErr

--- a/backend/app/adapter/github/identityprovider_integration_test.go
+++ b/backend/app/adapter/github/identityprovider_integration_test.go
@@ -5,7 +5,6 @@ package github
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -27,7 +26,6 @@ func TestIdentityProvider_GetAuthorizationURL(t *testing.T) {
 	urlResponse := identityProvider.GetAuthorizationURL()
 
 	parsedUrl, err := url.Parse(urlResponse)
-	fmt.Println(parsedUrl)
 	mdtest.Equal(t, nil, err)
 	mdtest.Equal(t, "https", parsedUrl.Scheme)
 	mdtest.Equal(t, "github.com", parsedUrl.Host)


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Didn't obtain user ID after he or she signed in through facebook account. 

## New Behavior
### Description
Retrieves user ID after he or she signed in through facebook account.
fixes #541 
