### PR TITLE
Create short link refactor

### DIFF
--- a/frontend/src/component/pages/Home.scss
+++ b/frontend/src/component/pages/Home.scss
@@ -56,10 +56,6 @@
     padding: 40px 0;
   }
 
-  .short-link-usage-wrapper {
-    margin-top: 40px;
-  }
-
   .err {
     background-color: #424242;
     box-sizing: border-box;
@@ -98,14 +94,5 @@
         opacity: 0.9;
       }
     }
-  }
-
-  .input-error {
-    color: #b71c1c;
-    font-size: 12px;
-    font-weight: $font-weight-semi-bold;
-    height: 20px;
-    line-height: 20px;
-    margin: 10px;
   }
 }

--- a/frontend/src/component/pages/shared/CreateShortLinkSection.scss
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.scss
@@ -1,0 +1,14 @@
+@import '../../styles/font';
+
+.short-link-usage-wrapper {
+  margin-top: 40px;
+}
+
+.input-error {
+  color: #b71c1c;
+  font-size: 12px;
+  font-weight: $font-weight-semi-bold;
+  height: 20px;
+  line-height: 20px;
+  margin: 10px;
+}

--- a/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
@@ -1,0 +1,76 @@
+import React, { Component, ReactElement } from 'react';
+
+import './CreateShortLinkSection.scss';
+import { TextField } from '../../form/TextField';
+import { Button } from '../../ui/Button';
+import { ShortLinkUsage } from './ShortLinkUsage';
+import { Section } from '../../ui/Section';
+import { Url } from '../../../entity/Url';
+
+interface Props {
+  longLinkText?: string;
+  alias?: string;
+  shortLink?: string;
+  inputErr?: string;
+  createdUrl?: Url;
+  qrCodeUrl?: string;
+  onLongLinkTextFieldBlur?: () => void;
+  onLongLinkTextFieldChange?: (newLongLink: string) => void;
+  onShortLinkTextFieldBlur?: () => void;
+  onShortLinkTextFieldChange?: (newAlias: string) => void;
+  onCreateShortLinkButtonClick?: () => void;
+}
+
+export class CreateShortLinkSection extends Component<Props> {
+  private shortLinkTextField = React.createRef<TextField>();
+
+  focusShortLinkTextField = () => {
+    if (!this.shortLinkTextField.current) {
+      return;
+    }
+    this.shortLinkTextField.current.focus();
+  };
+
+  render(): ReactElement {
+    return (
+      <Section title={'New Short Link'}>
+        <div className={'control create-short-link'}>
+          <div className={'text-field-wrapper'}>
+            <TextField
+              text={this.props.longLinkText}
+              placeHolder={'Long Link'}
+              onBlur={this.props.onLongLinkTextFieldBlur}
+              onChange={this.props.onLongLinkTextFieldChange}
+            />
+          </div>
+          <div className={'text-field-wrapper'}>
+            <TextField
+              ref={this.shortLinkTextField}
+              text={this.props.alias}
+              placeHolder={'Custom Short Link ( Optional )'}
+              onBlur={this.props.onShortLinkTextFieldBlur}
+              onChange={this.props.onShortLinkTextFieldChange}
+            />
+          </div>
+          <div className="create-short-link-btn">
+            <Button onClick={this.props.onCreateShortLinkButtonClick}>
+              Create Short Link
+            </Button>
+          </div>
+        </div>
+        <div className={'input-error'}>{this.props.inputErr}</div>
+        {this.props.createdUrl ? (
+          <div className={'short-link-usage-wrapper'}>
+            <ShortLinkUsage
+              shortLink={this.props.shortLink!}
+              originalUrl={this.props.createdUrl.originalUrl!}
+              qrCodeUrl={this.props.qrCodeUrl!}
+            />
+          </div>
+        ) : (
+          false
+        )}
+      </Section>
+    );
+  }
+}

--- a/frontend/src/component/pages/shared/Footer.tsx
+++ b/frontend/src/component/pages/shared/Footer.tsx
@@ -27,7 +27,7 @@ export class Footer extends Component<Props> {
             App version: {this.props.version}
           </div>
           {this.props.uiFactory.createViewChangeLogButton({
-            onClick: this.props. onShowChangeLogBtnClick
+            onClick: this.props.onShowChangeLogBtnClick
           })}
         </div>
       </footer>


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The current create short link component is nested inside home page. It's very difficult to read and understand. 

### Screenshots
<img width="769" alt="Screen Shot 2020-03-13 at 10 25 30 PM" src="https://user-images.githubusercontent.com/13726179/76675725-9399cd80-6579-11ea-8d65-16cedffe76d5.png">

## New Behavior
### Description
Extracted created short link section into its own component. It is much cleaner and easier to understand the structure of the homepage. 

### Screenshots
![Screen Shot 2020-03-13 at 10 26 59 PM](https://user-images.githubusercontent.com/13726179/76675741-c3e16c00-6579-11ea-8414-f79cff61b75e.png)

