### PR TITLE
Fix autofill long link bug

### DIFF
--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -241,6 +241,7 @@ export class Home extends Component<Props, State> {
         />
         <div className={'main'}>
           <CreateShortLinkSection
+            ref={this.createShortLinkSection}
             longLinkText={this.state.longLink}
             alias={this.state.alias}
             shortLink={this.state.shortLink}


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The following error occurs when the user try to use autofill long link feature 
### Screenshots
<img width="1440" alt="Screen Shot 2020-03-14 at 10 01 37 AM" src="https://user-images.githubusercontent.com/13726179/76689383-91c02080-65f2-11ea-9308-1b1ccf89ac9e.png">

## New Behavior
### Description
The bug is fixed
### Screenshots
<img width="1415" alt="Screen Shot 2020-03-14 at 12 52 48 PM" src="https://user-images.githubusercontent.com/13726179/76689396-b7e5c080-65f2-11ea-8a14-9412b140d544.png">
