### PR TITLE
Add gofmt to code formatters

### DIFF
--- a/backend/app/adapter/db/url_integration_test.go
+++ b/backend/app/adapter/db/url_integration_test.go
@@ -280,14 +280,14 @@ func TestURLSql_GetByAliases(t *testing.T) {
 			aliases: []string{"220uFicCJj", "yDOBcj5HIPbUAsw"},
 			hasErr:  false,
 			expectedURLs: []entity.URL{
-				entity.URL{
+				{
 					Alias:       "220uFicCJj",
 					OriginalURL: "http://www.google.com",
 					CreatedAt:   &twoYearsAgo,
 					ExpireAt:    &now,
 					UpdatedAt:   &now,
 				},
-				entity.URL{
+				{
 					Alias:       "yDOBcj5HIPbUAsw",
 					OriginalURL: "http://www.facebook.com",
 					CreatedAt:   &twoYearsAgo,

--- a/backend/scripts/format
+++ b/backend/scripts/format
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+gofmt -s -w .
 goimports -w .


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
`goimports` does not support `-s` ( simplify ) option.

### Screenshots
<img width="811" alt="Screen Shot 2020-03-14 at 3 52 10 PM" src="https://user-images.githubusercontent.com/3537801/76691804-2125fd80-660c-11ea-901b-eb23da5e0d97.png">

## New Behavior
### Description
Add gofmt to code formatters because it supports `-s` option.