### PR TITLE
Added LRU cache implementation

### DIFF
--- a/backend/app/adapter/cache/cache.go
+++ b/backend/app/adapter/cache/cache.go
@@ -35,7 +35,6 @@ func (c *Cache) Set(key interface{}, value []interface{}) {
 		node.Val = value
 		c.Remove(node)
 		c.Add(node)
-		return
 	} else {
 		node = &Node{Key: key, Val: value}
 		c.Mapping[key] = node

--- a/backend/app/adapter/cache/cache.go
+++ b/backend/app/adapter/cache/cache.go
@@ -1,0 +1,83 @@
+package cache
+
+// Cache stores key-value pair in memory,
+// it uses classic implementation of LRU cache
+type Cache struct {
+	Head     *Node
+	Tail     *Node
+	Mapping  map[interface{}]*Node
+	Capacity int
+}
+
+// Node defines a node in doubly linked list
+type Node struct {
+	Key  interface{}
+	Val  []interface{}
+	Prev *Node
+	Next *Node
+}
+
+// Get retrieves the value inside cache
+func (c *Cache) Get(key interface{}) []interface{} {
+	node, ok := c.Mapping[key]
+	if ok {
+		c.Remove(node)
+		c.Add(node)
+		return node.Val
+	}
+	return []interface{}{}
+}
+
+// Set sets the key-value pair into cache
+func (c *Cache) Set(key interface{}, value []interface{}) {
+	node, ok := c.Mapping[key]
+	if ok {
+		node.Val = value
+		c.Remove(node)
+		c.Add(node)
+		return
+	} else {
+		node = &Node{Key: key, Val: value}
+		c.Mapping[key] = node
+		c.Add(node)
+	}
+	if len(c.Mapping) > c.Capacity {
+		delete(c.Mapping, c.Tail.Key)
+		c.Remove(c.Tail)
+	}
+}
+
+// Add adds a new Node into the front of the doubly linked list
+func (c *Cache) Add(node *Node) {
+	node.Prev = nil
+	node.Next = c.Head
+	if c.Head != nil {
+		c.Head.Prev = node
+	}
+	c.Head = node
+	if c.Tail == nil {
+		c.Tail = node
+	}
+}
+
+// Remove removes a Node inside the doubly linked list
+func (c *Cache) Remove(node *Node) {
+	if node != c.Head {
+		node.Prev.Next = node.Next
+	} else {
+		c.Head = node.Next
+	}
+	if node != c.Tail {
+		node.Next.Prev = node.Prev
+	} else {
+		c.Tail = node.Prev
+	}
+}
+
+// NewCache creates a Cache object
+func NewCache(capacity int) Cache {
+	return Cache{
+		Mapping:  make(map[interface{}]*Node),
+		Capacity: capacity,
+	}
+}

--- a/backend/app/adapter/cache/cache_test.go
+++ b/backend/app/adapter/cache/cache_test.go
@@ -1,0 +1,236 @@
+package cache
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/short-d/app/mdtest"
+)
+
+func TestCache_Get(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cache       Cache
+		key         interface{}
+		expectedRes []interface{}
+		expectedSeq string
+	}{
+		{
+			name:        "success",
+			cache:       buildCache(10, 10),
+			key:         "5",
+			expectedRes: []interface{}{"5"},
+			expectedSeq: "5->0->1->2->3->4->6->7->8->9",
+		},
+		{
+			name:        "not found",
+			cache:       buildCache(11, 11),
+			key:         "12",
+			expectedRes: []interface{}{},
+			expectedSeq: "0->1->2->3->4->5->6->7->8->9->10",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			res := testCase.cache.Get(testCase.key)
+
+			mdtest.Equal(t, testCase.expectedRes, res)
+			mdtest.Equal(t, testCase.expectedSeq, nodeToString(testCase.cache.Head))
+		})
+	}
+}
+
+func TestCache_Set(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cache       Cache
+		key         interface{}
+		value       []interface{}
+		expectedVal []interface{}
+		expectedSeq string
+	}{
+		{
+			name:        "cache does not reach capacity and key does not exist",
+			cache:       buildCache(10, 8),
+			key:         "8",
+			value:       []interface{}{"k"},
+			expectedVal: []interface{}{"k"},
+			expectedSeq: "8->0->1->2->3->4->5->6->7",
+		},
+		{
+			name:        "cache does not reach capacity and key exists",
+			cache:       buildCache(10, 8),
+			key:         "3",
+			value:       []interface{}{"d"},
+			expectedVal: []interface{}{"d"},
+			expectedSeq: "3->0->1->2->4->5->6->7",
+		},
+		{
+			name:        "cache does reach capacity and key does not exist",
+			cache:       buildCache(11, 11),
+			key:         "11",
+			value:       []interface{}{"11"},
+			expectedVal: []interface{}{"11"},
+			expectedSeq: "11->0->1->2->3->4->5->6->7->8->9",
+		},
+		{
+			name:        "cache does not reach capacity and key does not exists",
+			cache:       buildCache(10, 8),
+			key:         "22",
+			value:       []interface{}{"22"},
+			expectedVal: []interface{}{"22"},
+			expectedSeq: "22->0->1->2->3->4->5->6->7",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.cache.Set(testCase.key, testCase.value)
+
+			mdtest.Equal(t, testCase.expectedVal, testCase.cache.Mapping[testCase.key].Val)
+			mdtest.Equal(t, testCase.expectedSeq, nodeToString(testCase.cache.Head))
+		})
+	}
+}
+
+func TestCache_Add(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cache       Cache
+		node        *Node
+		expectedRes string
+	}{
+		{
+			name:  "empty linkedlist",
+			cache: NewCache(10),
+			node: &Node{
+				Key: "1",
+			},
+			expectedRes: "1",
+		},
+		{
+			name: "non-empty linkedlist",
+			cache: func() Cache {
+				cache := NewCache(10)
+				node1 := Node{
+					Key: "1",
+				}
+				node2 := Node{
+					Key: "2",
+				}
+				node1.Next = &node2
+				node2.Prev = &node1
+				cache.Head = &node1
+				cache.Tail = &node2
+				return cache
+			}(),
+			node: &Node{
+				Key: "3",
+			},
+			expectedRes: "3->1->2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.cache.Add(testCase.node)
+
+			mdtest.Equal(t, testCase.expectedRes, nodeToString(testCase.cache.Head))
+		})
+	}
+}
+
+func TestCache_Remove(t *testing.T) {
+	cache1 := buildCache(1, 1)
+	cache2 := buildCache(3, 3)
+	cache3 := buildCache(3, 3)
+	cache4 := buildCache(3, 3)
+
+	testCases := []struct {
+		name        string
+		cache       Cache
+		node        *Node
+		expectedRes string
+	}{
+		{
+			name:        "single node",
+			cache:       cache1,
+			node:        cache1.Head,
+			expectedRes: "nil",
+		},
+		{
+			name:        "multiple nodes: remove Head",
+			cache:       cache2,
+			node:        cache2.Head,
+			expectedRes: "1->2",
+		},
+		{
+			name:        "multiple nodes: remove Tail",
+			cache:       cache3,
+			node:        cache3.Tail,
+			expectedRes: "0->1",
+		},
+		{
+			name:        "multiple nodes: remove middle",
+			cache:       cache4,
+			node:        cache4.Head.Next,
+			expectedRes: "0->2",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.cache.Remove(testCase.node)
+
+			mdtest.Equal(t, testCase.expectedRes, nodeToString(testCase.cache.Head))
+		})
+	}
+}
+
+func TestNewCache(t *testing.T) {
+	cache := NewCache(1)
+	mdtest.NotEqual(t, nil, cache)
+	mdtest.Equal(t, 1, cache.Capacity)
+}
+
+// nodeToString converts node key to its string representation
+func nodeToString(node *Node) string {
+	if node == nil {
+		return "nil"
+	}
+
+	var nodeStr string
+	for node != nil {
+		nodeStr = nodeStr + node.Key.(string) + "->"
+		node = node.Next
+	}
+	return nodeStr[:len(nodeStr)-2]
+}
+
+// buildCache returns a Cache with a doubly linked list of key 0->1->2->3->...
+func buildCache(capacity int, size int) Cache {
+	cache := NewCache(capacity)
+	nodeList := make([]Node, size)
+	for i := 0; i < len(nodeList); i++ {
+		key := strconv.Itoa(i)
+		val := []interface{}{strconv.Itoa(i)}
+		nodeList[i] = Node{
+			Key: key,
+			Val: val,
+		}
+		cache.Mapping[key] = &nodeList[i]
+	}
+	for i := 1; i < len(nodeList)-1; i++ {
+		nodeList[i].Prev = &nodeList[i-1]
+		nodeList[i].Next = &nodeList[i+1]
+	}
+	if size > 1 {
+		nodeList[0].Next = &nodeList[1]
+		nodeList[len(nodeList)-1].Prev = &nodeList[len(nodeList)-2]
+	}
+
+	cache.Head = &nodeList[0]
+	cache.Tail = &nodeList[len(nodeList)-1]
+	return cache
+}

--- a/backend/app/adapter/cache/cache_test.go
+++ b/backend/app/adapter/cache/cache_test.go
@@ -75,12 +75,12 @@ func TestCache_Set(t *testing.T) {
 			expectedSeq: "11->0->1->2->3->4->5->6->7->8->9",
 		},
 		{
-			name:        "cache does not reach capacity and key does not exists",
+			name:        "cache does reach capacity and key does exists",
 			cache:       buildCache(10, 8),
-			key:         "22",
-			value:       []interface{}{"22"},
-			expectedVal: []interface{}{"22"},
-			expectedSeq: "22->0->1->2->3->4->5->6->7",
+			key:         "2",
+			value:       []interface{}{"x"},
+			expectedVal: []interface{}{"x"},
+			expectedSeq: "2->0->1->3->4->5->6->7",
 		},
 	}
 

--- a/backend/app/adapter/cache/cache_test.go
+++ b/backend/app/adapter/cache/cache_test.go
@@ -75,7 +75,7 @@ func TestCache_Set(t *testing.T) {
 			expectedSeq: "11->0->1->2->3->4->5->6->7->8->9",
 		},
 		{
-			name:        "cache does reach capacity and key does exists",
+			name:        "cache does reach capacity and key exists",
 			cache:       buildCache(10, 8),
 			key:         "2",
 			value:       []interface{}{"x"},


### PR DESCRIPTION
## New Behavior
### Description
Added LRU cache implementation.

User should be able to search the public and the private short links they created. In order to support that, we add RESTful API to search for all urls created by a given user. In order to support caching URLs to reduce traffic to DB, we need to add cache.