### PR TITLE
Copy generated link to user's clipboard automatically

### DIFF
--- a/frontend/src/component/UIFactory.tsx
+++ b/frontend/src/component/UIFactory.tsx
@@ -19,10 +19,12 @@ import { SearchService } from '../service/Search.service';
 import { SearchBar } from './ui/SearchBar';
 import { ViewChangeLogButton } from './ui/ViewChangeLogButton';
 import { ChangeLogService } from '../service/ChangeLog.service';
+import { ClipboardService } from '../service/utilities/Clipboard.service';
 
 export class UIFactory {
   constructor(
     private authService: AuthService,
+    private clipboardService: ClipboardService,
     private extensionService: IBrowserExtensionService,
     private urlService: UrlService,
     private qrCodeService: QrCodeService,
@@ -40,6 +42,7 @@ export class UIFactory {
       <Home
         uiFactory={this}
         authService={this.authService}
+        clipboardService={this.clipboardService}
         extensionService={this.extensionService}
         qrCodeService={this.qrCodeService}
         versionService={this.versionService}

--- a/frontend/src/component/ui/Toast.scss
+++ b/frontend/src/component/ui/Toast.scss
@@ -1,0 +1,33 @@
+@import '../styles/color';
+@import '../styles/corner';
+@import '../styles/font';
+@import '../styles/layouts';
+
+.toast:hover {
+  opacity: 1;
+  cursor: pointer;
+}
+
+.toast-message {
+  font-size: 14px;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @include default-font;
+}
+
+.toast {
+  z-index: 10000;
+  width: 80vw;
+  max-width: 300px;
+  color: #dedede;
+  background-color: $color-dark-gray;
+  position: fixed;
+  opacity: 0.9;
+  bottom: 5vh;
+  left: 50%;
+  transform: translateX(-50%);
+
+  @include round-corner;
+}

--- a/frontend/src/component/ui/Toast.tsx
+++ b/frontend/src/component/ui/Toast.tsx
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+
+import './Toast.scss';
+
+interface Props {
+  toastMessage: string;
+}
+
+interface States {
+  isShown: boolean;
+}
+
+export class Toast extends Component<Props, States> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isShown: false
+    };
+  }
+
+  showAndHide(delay: number) {
+    // return if the toast is already being shown
+    if (this.state.isShown) return;
+
+    this.show();
+    setTimeout(() => {
+      this.hide();
+    }, delay);
+  }
+
+  show() {
+    this.setState({
+      isShown: true
+    });
+  }
+
+  hide() {
+    this.setState({
+      isShown: false
+    });
+  }
+
+  render() {
+    const { toastMessage } = this.props;
+
+    return (
+      this.state.isShown && (
+        <div className={`toast`}>
+          <div>
+            <p className="toast-message">{toastMessage}</p>
+          </div>
+        </div>
+      )
+    );
+  }
+}

--- a/frontend/src/dep.ts
+++ b/frontend/src/dep.ts
@@ -14,6 +14,7 @@ import { UrlService } from './service/Url.service';
 import { SearchService } from './service/Search.service';
 import { BrowserExtensionFactory } from './service/extensionService/BrowserExtension.factory';
 import { ChangeLogService } from './service/ChangeLog.service';
+import { ClipboardService } from './service/utilities/Clipboard.service';
 
 export function initEnvService(): EnvService {
   return new EnvService();
@@ -51,9 +52,11 @@ export function initUIFactory(
   const extensionService = BrowserExtensionFactory.createBrowserExtensionService(
     envService
   );
+  const clipboardService = new ClipboardService();
 
   return new UIFactory(
     authService,
+    clipboardService,
     extensionService,
     urlService,
     qrCodeService,

--- a/frontend/src/service/extensionService/BrowserExtension.service.ts
+++ b/frontend/src/service/extensionService/BrowserExtension.service.ts
@@ -1,5 +1,3 @@
-import { EnvService } from '../Env.service';
-
 export interface IBrowserExtensionService {
   isSupported(): boolean;
   isInstalled(): Promise<boolean>;

--- a/frontend/src/service/utilities/Clipboard.service.ts
+++ b/frontend/src/service/utilities/Clipboard.service.ts
@@ -1,0 +1,48 @@
+export class ClipboardService {
+  private fallbackCopyTextToClipboard(text: string): boolean {
+    let textArea = document.createElement('textarea');
+
+    // set minimal visual effects in case textarea flashes
+    textArea.style.position = 'fixed';
+    textArea.style.top = '0';
+    textArea.style.left = '0';
+
+    textArea.style.width = '2em';
+    textArea.style.height = '2em';
+
+    textArea.style.padding = '0';
+    textArea.style.border = 'none';
+    textArea.style.outline = 'none';
+    textArea.style.boxShadow = 'none';
+    textArea.style.background = 'transparent';
+
+    textArea.value = text;
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    let successful = false;
+    try {
+      successful = document.execCommand('copy');
+    } catch (err) {}
+
+    document.body.removeChild(textArea);
+    return successful;
+  }
+
+  public copyTextToClipboard(text: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (!navigator.clipboard) {
+        // fallback mechanism if browser doesn't support navigator
+        this.fallbackCopyTextToClipboard(text) ? resolve() : reject();
+        return;
+      }
+      navigator.clipboard
+        .writeText(text)
+        .then(() => resolve())
+        .catch(() => reject());
+      return;
+    });
+  }
+}


### PR DESCRIPTION
Fixes #527 
## New Behavior
### Description
If the short link creation is successful, the generated link is copied to user's clipboard automatically and shows a toast to notify the behavior.
### Screenshots
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/18581705/77111583-9a2eb600-6a4d-11ea-8e68-cad0e0ea47d2.png">
