### PR TITLE
Add instruction for weekly standups to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please post your weekly contributions on our Slack every Friday during your conv
 
 - Exploring the codebase
 - Learnings new tools, infrastructures, libraries, algorithms, designs, or concepts
-- Experimenting with diffierent technologies and sharing the findings with the group
+- Experimenting with different technologies and sharing the findings with the group
 - Prototyping new features
 - Fixing bugs
 - Improving maintainability, scalability, reliability and performance of existing system
@@ -119,4 +119,3 @@ Note: This guideline is derived from [Google Engineering Practices Documentation
 
 Please join this [Slack channel](https://short-d.com/r/slack) to
 discuss bugs, dev environment setup, tooling, and coding best practices.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,22 @@ to make via [Slack channel](https://short-d.com/r/slack) with the owner
 of this repository before making a change.
 
 Please open a draft pull request when you are working on an issue so that the
-owner knows it is in progress. The owner may take over or reassign the issue if no
-body replies after 10 days assigned to you.
+owner knows it is in progress. The owner may take over or reassign the issue if no body replies after 10 days assigned to you.
+
+Please post your weekly contributions on our Slack every Friday during your convenient hours. All of the followings counts as contributions: 
+
+- Exploring the codebase
+- Learnings new tools, infrastructures, libraries, algorithms, designs, or concepts
+- Experimenting with diffierent technologies and sharing the findings with the group
+- Prototyping new features
+- Fixing bugs
+- Improving maintainability, scalability, reliability and performance of existing system
+- Doing code reviews
+- Writing design docs
+- Creating UI mockups
+- Organizing or participating sync meetings
+
+The owner reserves the rights to deactivate your Slack account after missing 3 consecutive standups without any heads up.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
There is no clear instruction on how our weekly standups are organized. It's difficult to plan the works and track executions without reinforcing weekly standups.

## New Behavior
### Description
Included instructions and requirements for contributors to join our weekly standups.
