### PR TITLE
Fix short link usage original URL display bug

### DIFF
--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -211,7 +211,6 @@ export class Home extends Component<Props, State> {
     this.props.urlService
       .createShortLink(editingUrl)
       .then((createdUrl: Url) => {
-        console.log('Create Short Link response: ', createdUrl);
         this.props.store.dispatch(updateCreatedUrl(createdUrl));
       })
       .catch(({ authorizationErr, createShortLinkErr }) => {

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -210,9 +210,10 @@ export class Home extends Component<Props, State> {
     const editingUrl = this.props.store.getState().editingUrl;
     this.props.urlService
       .createShortLink(editingUrl)
-      .then((createdUrl: Url) =>
-        this.props.store.dispatch(updateCreatedUrl(createdUrl))
-      )
+      .then((createdUrl: Url) => {
+        console.log('Create Short Link response: ', createdUrl);
+        this.props.store.dispatch(updateCreatedUrl(createdUrl));
+      })
       .catch(({ authorizationErr, createShortLinkErr }) => {
         if (authorizationErr) {
           this.requestSignIn();

--- a/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
@@ -59,7 +59,7 @@ export class CreateShortLinkSection extends Component<Props> {
           </div>
         </div>
         <div className={'input-error'}>{this.props.inputErr}</div>
-        {this.props.createdUrl ? (
+        {this.props.createdUrl && (
           <div className={'short-link-usage-wrapper'}>
             <ShortLinkUsage
               shortLink={this.props.shortLink!}
@@ -67,8 +67,6 @@ export class CreateShortLinkSection extends Component<Props> {
               qrCodeUrl={this.props.qrCodeUrl!}
             />
           </div>
-        ) : (
-          false
         )}
       </Section>
     );

--- a/frontend/src/component/pages/shared/ShortLinkUsage.tsx
+++ b/frontend/src/component/pages/shared/ShortLinkUsage.tsx
@@ -10,7 +10,6 @@ interface Props {
 
 export class ShortLinkUsage extends Component<Props> {
   render() {
-    console.log('ShortLinkUsage: originalUrl', this.props.originalUrl);
     return (
       <div className={'short-link-usage'}>
         <div>

--- a/frontend/src/component/pages/shared/ShortLinkUsage.tsx
+++ b/frontend/src/component/pages/shared/ShortLinkUsage.tsx
@@ -10,6 +10,7 @@ interface Props {
 
 export class ShortLinkUsage extends Component<Props> {
   render() {
+    console.log('ShortLinkUsage: originalUrl', this.props.originalUrl);
     return (
       <div className={'short-link-usage'}>
         <div>

--- a/frontend/src/entity/Url.tsx
+++ b/frontend/src/entity/Url.tsx
@@ -1,4 +1,4 @@
 export interface Url {
-  originalUrl?: string;
-  alias?: string;
+  originalUrl: string;
+  alias: string;
 }

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -140,7 +140,7 @@ export class UrlService {
     );
     let alias = link.alias === '' ? null : link.alias!;
     let variables = this.gqlCreateURLVariable(captchaResponse, link, alias);
-    return new Promise<Url>( // TODO: simplify business logic below
+    return new Promise<Url>( // TODO(issue#599): simplify business logic below to improve readability
       (
         resolve: (createdURL: Url) => void,
         reject: (errCodes: Err[]) => any

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -140,7 +140,7 @@ export class UrlService {
     );
     let alias = link.alias === '' ? null : link.alias!;
     let variables = this.gqlCreateURLVariable(captchaResponse, link, alias);
-    return new Promise<Url>(
+    return new Promise<Url>( // TODO: simplify business logic below
       (
         resolve: (createdURL: Url) => void,
         reject: (errCodes: Err[]) => any


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
When createdUrl object is fetched from GraphQL API, the originalUrl field is named as 'originalURL' due to Golang's convention, which makes displaying the original URL in the UI impossible. The user will see the following when they create a short link.
### Screenshots
<img width="1440" alt="76887950-0de38e00-68a9-11ea-8c95-02b4685bbc52" src="https://user-images.githubusercontent.com/13726179/77242273-04646980-6bba-11ea-8d40-721cb3ec7150.png">

## New Behavior
### Description
Fixed the createdUrl object by creating a new type as the receiver of GraphQL response, which gets converted to the properly named createdUrl object (with the field 'originalUrl' rather than 'originalURL') for JavaScript to process. Now the user is able to see the original URL in the UI after they've created a short link. 
### Screenshots
![Screen Shot 2020-03-21 at 9 27 31 PM](https://user-images.githubusercontent.com/13726179/77242365-d03d7880-6bba-11ea-909e-adcbe19e37f0.png)
