### PR TITLE
Add Email payload

### DIFF
--- a/backend/app/adapter/graphql/resolver/authquery_test.go
+++ b/backend/app/adapter/graphql/resolver/authquery_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/short-d/app/mdtest"
 	"github.com/short-d/short/app/adapter/db"
 	"github.com/short-d/short/app/adapter/graphql/scalar"
+	"github.com/short-d/short/app/entity"
 	"github.com/short-d/short/app/usecase/changelog"
 	"github.com/short-d/short/app/usecase/keygen"
-	"github.com/short-d/short/app/usecase/service"
-	"github.com/short-d/short/app/entity"
 	"github.com/short-d/short/app/usecase/repository"
+	"github.com/short-d/short/app/usecase/service"
 	"github.com/short-d/short/app/usecase/url"
 )
 

--- a/backend/app/adapter/graphql/resolver/query_test.go
+++ b/backend/app/adapter/graphql/resolver/query_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/short-d/short/app/adapter/db"
-	"github.com/short-d/short/app/usecase/changelog"
-	"github.com/short-d/short/app/usecase/keygen"
-	"github.com/short-d/short/app/usecase/service"
 	"github.com/short-d/app/mdtest"
+	"github.com/short-d/short/app/adapter/db"
 	"github.com/short-d/short/app/entity"
 	"github.com/short-d/short/app/usecase/auth"
+	"github.com/short-d/short/app/usecase/changelog"
+	"github.com/short-d/short/app/usecase/keygen"
 	"github.com/short-d/short/app/usecase/repository"
+	"github.com/short-d/short/app/usecase/service"
 	"github.com/short-d/short/app/usecase/url"
 )
 

--- a/backend/app/usecase/auth/payload/email.go
+++ b/backend/app/usecase/auth/payload/email.go
@@ -9,7 +9,7 @@ import (
 
 var _ Payload = (*Email)(nil)
 
-// Email represents a payload contains user's email
+// Email represents a payload that contains user's email
 type Email struct {
 	user entity.User
 }
@@ -47,7 +47,7 @@ func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, e
 	return Email{user: user}, nil
 }
 
-// FromUser coverts user info into email payload.
+// FromUser converts user info into email payload.
 func (e EmailFactory) FromUser(user entity.User) (Payload, error) {
 	if user.Email == "" {
 		return nil, errors.New("user email cannot be empty")

--- a/backend/app/usecase/auth/payload/email.go
+++ b/backend/app/usecase/auth/payload/email.go
@@ -1,0 +1,53 @@
+package payload
+
+import (
+	"errors"
+
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/entity"
+)
+
+var _ Payload = (*Email)(nil)
+
+type Email struct {
+	User entity.User
+}
+
+func (e Email) GetTokenPayload() fw.TokenPayload {
+	return map[string]interface{}{
+		"email": e.User.Email,
+	}
+}
+
+func (e Email) GetUser() entity.User {
+	return e.User
+}
+
+var _ Factory = (*EmailFactory)(nil)
+
+type EmailFactory struct {
+}
+
+func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, error) {
+	JSONEmail := tokenPayload["email"]
+	email, ok := JSONEmail.(string)
+	if !ok {
+		return nil, errors.New("expect payload to contain email")
+	}
+
+	user := entity.User{
+		Email: email,
+	}
+	return Email{User: user}, nil
+}
+
+func (e EmailFactory) FromUser(user entity.User) (Payload, error) {
+	if user.Email == "" {
+		return nil, errors.New("user email cannot be empty")
+	}
+	return Email{User: user}, nil
+}
+
+func NewEmailFactory() EmailFactory {
+	return EmailFactory{}
+}

--- a/backend/app/usecase/auth/payload/email.go
+++ b/backend/app/usecase/auth/payload/email.go
@@ -9,25 +9,31 @@ import (
 
 var _ Payload = (*Email)(nil)
 
+// Email represents a payload contains user's email
 type Email struct {
 	user entity.User
 }
 
+// GetTokenPayload retrieves the token payload representation of the email
+// payload.
 func (e Email) GetTokenPayload() fw.TokenPayload {
 	return map[string]interface{}{
 		"email": e.user.Email,
 	}
 }
 
+// GetUser retrieves user info represented by the email payload.
 func (e Email) GetUser() entity.User {
 	return e.user
 }
 
 var _ Factory = (*EmailFactory)(nil)
 
+// EmailFactory produces email payload.
 type EmailFactory struct {
 }
 
+// FromTokenPayload parses token payload into email payload.
 func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, error) {
 	JSONEmail := tokenPayload["email"]
 	email, ok := JSONEmail.(string)
@@ -41,6 +47,7 @@ func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, e
 	return Email{user: user}, nil
 }
 
+// FromUser coverts user info into email payload.
 func (e EmailFactory) FromUser(user entity.User) (Payload, error) {
 	if user.Email == "" {
 		return nil, errors.New("user email cannot be empty")
@@ -48,6 +55,7 @@ func (e EmailFactory) FromUser(user entity.User) (Payload, error) {
 	return Email{user: user}, nil
 }
 
+// NewEmailFactory creates email payload factory.
 func NewEmailFactory() EmailFactory {
 	return EmailFactory{}
 }

--- a/backend/app/usecase/auth/payload/email.go
+++ b/backend/app/usecase/auth/payload/email.go
@@ -10,17 +10,17 @@ import (
 var _ Payload = (*Email)(nil)
 
 type Email struct {
-	User entity.User
+	user entity.User
 }
 
 func (e Email) GetTokenPayload() fw.TokenPayload {
 	return map[string]interface{}{
-		"email": e.User.Email,
+		"email": e.user.Email,
 	}
 }
 
 func (e Email) GetUser() entity.User {
-	return e.User
+	return e.user
 }
 
 var _ Factory = (*EmailFactory)(nil)
@@ -38,14 +38,14 @@ func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, e
 	user := entity.User{
 		Email: email,
 	}
-	return Email{User: user}, nil
+	return Email{user: user}, nil
 }
 
 func (e EmailFactory) FromUser(user entity.User) (Payload, error) {
 	if user.Email == "" {
 		return nil, errors.New("user email cannot be empty")
 	}
-	return Email{User: user}, nil
+	return Email{user: user}, nil
 }
 
 func NewEmailFactory() EmailFactory {

--- a/backend/app/usecase/auth/payload/email.go
+++ b/backend/app/usecase/auth/payload/email.go
@@ -7,6 +7,8 @@ import (
 	"github.com/short-d/short/app/entity"
 )
 
+const emailKey = "email"
+
 var _ Payload = (*Email)(nil)
 
 // Email represents a payload that contains user's email
@@ -18,7 +20,7 @@ type Email struct {
 // payload.
 func (e Email) GetTokenPayload() fw.TokenPayload {
 	return map[string]interface{}{
-		"email": e.user.Email,
+		emailKey: e.user.Email,
 	}
 }
 
@@ -35,7 +37,7 @@ type EmailFactory struct {
 
 // FromTokenPayload parses token payload into email payload.
 func (e EmailFactory) FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, error) {
-	JSONEmail := tokenPayload["email"]
+	JSONEmail := tokenPayload[emailKey]
 	email, ok := JSONEmail.(string)
 	if !ok {
 		return nil, errors.New("expect payload to contain email")

--- a/backend/app/usecase/auth/payload/email_test.go
+++ b/backend/app/usecase/auth/payload/email_test.go
@@ -1,0 +1,91 @@
+package payload
+
+import (
+	"testing"
+
+	"github.com/short-d/app/fw"
+	"github.com/short-d/app/mdtest"
+	"github.com/short-d/short/app/entity"
+)
+
+func TestEmailFactory_FromUser(t *testing.T) {
+	testCases := []struct {
+		name           string
+		user           entity.User
+		expectedHasErr bool
+		expectedEmail  string
+	}{
+		{
+			name: "user has email",
+			user: entity.User{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+			},
+			expectedHasErr: false,
+			expectedEmail:  "alpha@example.com",
+		},
+		{
+			name: "user email not found",
+			user: entity.User{
+				ID: "alpha",
+			},
+			expectedHasErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			emailPayloadFactory := NewEmailFactory()
+			emailPayload, err := emailPayloadFactory.FromUser(testCase.user)
+			if testCase.expectedHasErr {
+				mdtest.NotEqual(t, nil, err)
+				return
+			}
+			mdtest.Equal(t, nil, err)
+			tokenPayload := emailPayload.GetTokenPayload()
+			mdtest.Equal(t, testCase.expectedEmail, tokenPayload["email"])
+		})
+	}
+}
+
+func TestEmailFactory_FromTokenPayload(t *testing.T) {
+	testCases := []struct {
+		name           string
+		tokenPayload   fw.TokenPayload
+		expectedHasErr bool
+		expectedEmail  string
+	}{
+		{
+			name: "user has email",
+			tokenPayload: fw.TokenPayload{
+				"id":    "alpha",
+				"email": "alpha@example.com",
+			},
+			expectedHasErr: false,
+			expectedEmail:  "alpha@example.com",
+		},
+		{
+			name: "user email not found",
+			tokenPayload: fw.TokenPayload{
+				"id": "alpha",
+			},
+			expectedHasErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			emailPayloadFactory := NewEmailFactory()
+			emailPayload, err := emailPayloadFactory.FromTokenPayload(testCase.tokenPayload)
+			if testCase.expectedHasErr {
+				mdtest.NotEqual(t, nil, err)
+				return
+			}
+			mdtest.Equal(t, nil, err)
+			gotUser := emailPayload.GetUser()
+			mdtest.Equal(t, testCase.expectedEmail, gotUser.Email)
+		})
+	}
+}

--- a/backend/app/usecase/auth/payload/factory.go
+++ b/backend/app/usecase/auth/payload/factory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/short-d/short/app/entity"
 )
 
+// Factory creates payload based on metadata provided.
 type Factory interface {
 	FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, error)
 	FromUser(user entity.User) (Payload, error)

--- a/backend/app/usecase/auth/payload/factory.go
+++ b/backend/app/usecase/auth/payload/factory.go
@@ -1,0 +1,11 @@
+package payload
+
+import (
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/entity"
+)
+
+type Factory interface {
+	FromTokenPayload(tokenPayload fw.TokenPayload) (Payload, error)
+	FromUser(user entity.User) (Payload, error)
+}

--- a/backend/app/usecase/auth/payload/payload.go
+++ b/backend/app/usecase/auth/payload/payload.go
@@ -5,7 +5,7 @@ import (
 	"github.com/short-d/short/app/entity"
 )
 
-// Payload represents the metadata encoded in a message.
+// Payload represents a message with encoded metadata.
 type Payload interface {
 	GetTokenPayload() fw.TokenPayload
 	GetUser() entity.User

--- a/backend/app/usecase/auth/payload/payload.go
+++ b/backend/app/usecase/auth/payload/payload.go
@@ -5,6 +5,7 @@ import (
 	"github.com/short-d/short/app/entity"
 )
 
+// Payload represents the metadata encoded in a message.
 type Payload interface {
 	GetTokenPayload() fw.TokenPayload
 	GetUser() entity.User

--- a/backend/app/usecase/auth/payload/payload.go
+++ b/backend/app/usecase/auth/payload/payload.go
@@ -1,0 +1,11 @@
+package payload
+
+import (
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/entity"
+)
+
+type Payload interface {
+	GetTokenPayload() fw.TokenPayload
+	GetUser() entity.User
+}

--- a/backend/app/usecase/auth/payloadtest/factory_stub.go
+++ b/backend/app/usecase/auth/payloadtest/factory_stub.go
@@ -1,0 +1,23 @@
+package payloadtest
+
+import (
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/entity"
+	"github.com/short-d/short/app/usecase/auth/payload"
+)
+
+var _ Factory = (*FactoryStub)(nil)
+
+type FactoryStub struct {
+	Payload  Payload
+	TokenErr error
+	UserErr  error
+}
+
+func (f FactoryStub) FromTokenPayload(tokenPayload fw.TokenPayload) (payload.Payload, error) {
+	return f.Payload, f.TokenErr
+}
+
+func (f FactoryStub) FromUser(user entity.User) (payload.Payload, error) {
+	return f.Payload, f.UserErr
+}

--- a/backend/app/usecase/auth/payloadtest/factory_stub.go
+++ b/backend/app/usecase/auth/payloadtest/factory_stub.go
@@ -8,16 +8,19 @@ import (
 
 var _ payload.Factory = (*FactoryStub)(nil)
 
+// FactoryStub creates payloads based on preset data.
 type FactoryStub struct {
 	Payload  payload.Payload
 	TokenErr error
 	UserErr  error
 }
 
+// FromTokenPayload creates payload based on preset payload and error.
 func (f FactoryStub) FromTokenPayload(tokenPayload fw.TokenPayload) (payload.Payload, error) {
 	return f.Payload, f.TokenErr
 }
 
+// FromUser creates payload based on preset payload and error.
 func (f FactoryStub) FromUser(user entity.User) (payload.Payload, error) {
 	return f.Payload, f.UserErr
 }

--- a/backend/app/usecase/auth/payloadtest/factory_stub.go
+++ b/backend/app/usecase/auth/payloadtest/factory_stub.go
@@ -6,10 +6,10 @@ import (
 	"github.com/short-d/short/app/usecase/auth/payload"
 )
 
-var _ Factory = (*FactoryStub)(nil)
+var _ payload.Factory = (*FactoryStub)(nil)
 
 type FactoryStub struct {
-	Payload  Payload
+	Payload  payload.Payload
 	TokenErr error
 	UserErr  error
 }

--- a/backend/app/usecase/auth/payloadtest/payload_stub.go
+++ b/backend/app/usecase/auth/payloadtest/payload_stub.go
@@ -1,0 +1,21 @@
+package payloadtest
+
+import (
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/entity"
+)
+
+var _ Payload = (*Stub)(nil)
+
+type Stub struct {
+	TokenPayload fw.TokenPayload
+	User         entity.User
+}
+
+func (s Stub) GetTokenPayload() fw.TokenPayload {
+	return s.TokenPayload
+}
+
+func (s Stub) GetUser() entity.User {
+	return s.User
+}

--- a/backend/app/usecase/auth/payloadtest/payload_stub.go
+++ b/backend/app/usecase/auth/payloadtest/payload_stub.go
@@ -8,15 +8,18 @@ import (
 
 var _ payload.Payload = (*Stub)(nil)
 
+// Stub represents a payload with preset data.
 type Stub struct {
 	TokenPayload fw.TokenPayload
 	User         entity.User
 }
 
+// GetTokenPayload generates token payload based on preset data.
 func (s Stub) GetTokenPayload() fw.TokenPayload {
 	return s.TokenPayload
 }
 
+// GetUser retrieves the user based on preset data.
 func (s Stub) GetUser() entity.User {
 	return s.User
 }

--- a/backend/app/usecase/auth/payloadtest/payload_stub.go
+++ b/backend/app/usecase/auth/payloadtest/payload_stub.go
@@ -3,9 +3,10 @@ package payloadtest
 import (
 	"github.com/short-d/app/fw"
 	"github.com/short-d/short/app/entity"
+	"github.com/short-d/short/app/usecase/auth/payload"
 )
 
-var _ Payload = (*Stub)(nil)
+var _ payload.Payload = (*Stub)(nil)
 
 type Stub struct {
 	TokenPayload fw.TokenPayload


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Authenticator is hardcoded to use email as default unique ID. The email payload validation logic is nested inside authenticator, making it difficult to switch to userID for only some cases.

## New Behavior
### Description
Decouple and encapsulated all email payload logics into `payload.Email`.