### PR TITLE
Fix table header not filling background with change in header width

### DIFF
--- a/frontend/src/component/ui/Table.scss
+++ b/frontend/src/component/ui/Table.scss
@@ -12,7 +12,7 @@
     border-collapse: collapse;
     width: 100%;
 
-    thead {
+    th {
       background-color: $color-table-header-background;
     }
 


### PR DESCRIPTION
Change thead to th for table header CSS selector

## Current Behavior ( Optional for new feature )
### Description
- The table header's background is not re-rendered when `thead` CSS selector is used.

### Screenshots
![Pagination.gif](https://user-images.githubusercontent.com/18581705/78508054-a9c63280-77a1-11ea-8aef-eddadf530a2e.gif)

## New Behavior
### Description
- Changing the selector to `th` fixes the issue.

### Screenshots
![thFixed](https://user-images.githubusercontent.com/18581705/78528570-4f5abf80-77fd-11ea-9333-8c81126adbce.gif)
