### PR TITLE
Add meaningful error message for invalid recaptcha site key

### DIFF
--- a/frontend/src/service/Captcha.service.ts
+++ b/frontend/src/service/Captcha.service.ts
@@ -1,5 +1,6 @@
 import { load } from 'recaptcha-v3';
 import { EnvService } from './Env.service';
+import { Err } from './Error.service';
 
 export interface ReCaptcha {
   execute: (action: string) => Promise<string>;
@@ -8,8 +9,11 @@ export interface ReCaptcha {
 export const CREATE_SHORT_LINK = 'createShortLink';
 export const SEARCH_SHORT_LINK = 'searchShortLink';
 
+const INVALID_SITE_KEY_ERR_MSG = 'Invalid site key or not loaded in api.js';
+
 export class CaptchaService {
   private reCaptcha?: ReCaptcha;
+
   constructor(private envService: EnvService) {}
 
   public initRecaptchaV3(): Promise<void> {
@@ -21,9 +25,24 @@ export class CaptchaService {
   }
 
   public execute(action: string): Promise<string> {
-    if (!this.reCaptcha) {
-      return Promise.reject('ReCaptcha is not ready yet');
-    }
-    return this.reCaptcha.execute(action);
+    return new Promise<string>((resolve, reject) => {
+      if (!this.reCaptcha) {
+        reject(Err.ReCaptchaNotReady);
+        return;
+      }
+
+      this.reCaptcha.execute(action).then(resolve, err => {
+        const errMsg = err.message;
+        if (CaptchaService.contains(errMsg, INVALID_SITE_KEY_ERR_MSG)) {
+          reject(Err.InvalidRecaptchaSiteKey);
+          return;
+        }
+        reject(Err.Unknown);
+      });
+    });
+  }
+
+  private static contains(text: string, substr: string): boolean {
+    return text.indexOf(substr) > -1;
   }
 }

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -1,6 +1,8 @@
 import { IErr } from '../entity/Err';
 
 export enum Err {
+  ReCaptchaNotReady = 'reCaptchaNotReady',
+  InvalidRecaptchaSiteKey = 'invalidRecaptchaSiteKey',
   AliasAlreadyExist = 'aliasAlreadyExist',
   UserNotHuman = 'requesterNotHuman',
   Unauthorized = 'invalidAuthToken',
@@ -15,6 +17,13 @@ const unknownErr = {
                 Please email byliuyang11@gmail.com the screenshots and detailed 
                 steps to reproduce it so that I can investigate.
                 `
+};
+
+const invalidRecaptchaSiteKeyErr = {
+  name: 'Invalid reCaptcha site key',
+  description: `
+  Please email byliuyang11@gmail.com the screenshots and detailed steps to 
+  reproduce it so that I can investigate.`
 };
 
 const aliasNotAvailableErr = {
@@ -51,6 +60,8 @@ export class ErrorService {
         return userNotHumanErr;
       case Err.NetworkError:
         return networkErr;
+      case Err.InvalidRecaptchaSiteKey:
+        return invalidRecaptchaSiteKeyErr;
       case Err.Unknown:
       default:
         return unknownErr;

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -2,7 +2,7 @@ import { IErr } from '../entity/Err';
 
 export enum Err {
   ReCaptchaNotReady = 'reCaptchaNotReady',
-  InvalidRecaptchaSiteKey = 'invalidRecaptchaSiteKey',
+  InvalidReCaptchaSiteKey = 'invalidReCaptchaSiteKey',
   AliasAlreadyExist = 'aliasAlreadyExist',
   UserNotHuman = 'requesterNotHuman',
   Unauthorized = 'invalidAuthToken',
@@ -19,7 +19,7 @@ const unknownErr = {
                 `
 };
 
-const invalidRecaptchaSiteKeyErr = {
+const invalidReCaptchaSiteKeyErr = {
   name: 'Invalid reCaptcha site key',
   description: `
   Please email byliuyang11@gmail.com the screenshots and detailed steps to 
@@ -60,8 +60,8 @@ export class ErrorService {
         return userNotHumanErr;
       case Err.NetworkError:
         return networkErr;
-      case Err.InvalidRecaptchaSiteKey:
-        return invalidRecaptchaSiteKeyErr;
+      case Err.InvalidReCaptchaSiteKey:
+        return invalidReCaptchaSiteKeyErr;
       case Err.Unknown:
       default:
         return unknownErr;


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Unknown error is shown when developers forgot to configure reCaptcha site key during local development. This cause lots of confusion for devs It's waste of time to debug this issue during development.

### Screenshots
<img width="771" alt="Screen Shot 2020-04-07 at 10 21 13 PM" src="https://user-images.githubusercontent.com/3537801/78747514-6ba24d80-791e-11ea-8792-bf927d860774.png">

## New Behavior
### Description
Change the title of invalid reCaptcha site key error to `Invalid ReCaptcha Site key`.

### Screenshots
<img width="901" alt="Screen Shot 2020-04-07 at 8 46 23 PM" src="https://user-images.githubusercontent.com/3537801/78747678-d6ec1f80-791e-11ea-8526-428f93e99c29.png">
