### PR TITLE
Promote sign in after auth token expired

### DIFF
--- a/backend/app/adapter/graphql/resolver/authquery.go
+++ b/backend/app/adapter/graphql/resolver/authquery.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/short-d/short/app/adapter/graphql/scalar"
-	"github.com/short-d/short/app/entity"
+	"github.com/short-d/short/app/usecase/auth"
 	"github.com/short-d/short/app/usecase/changelog"
 	"github.com/short-d/short/app/usecase/url"
 )
@@ -12,9 +12,10 @@ import (
 // AuthQuery represents GraphQL query resolver that acts differently based
 // on the identify of the user
 type AuthQuery struct {
-	user         *entity.User
-	changeLog    changelog.ChangeLog
-	urlRetriever url.Retriever
+	authToken     *string
+	authenticator auth.Authenticator
+	changeLog     changelog.ChangeLog
+	urlRetriever  url.Retriever
 }
 
 // URLArgs represents possible parameters for URL endpoint
@@ -44,10 +45,16 @@ func (v AuthQuery) ChangeLog() (ChangeLog, error) {
 	return newChangeLog(changeLog, lastViewedAt), err
 }
 
-func newAuthQuery(user *entity.User, changeLog changelog.ChangeLog, urlRetriever url.Retriever) AuthQuery {
+func newAuthQuery(
+	authToken *string,
+	authenticator auth.Authenticator,
+	changeLog changelog.ChangeLog,
+	urlRetriever url.Retriever,
+) AuthQuery {
 	return AuthQuery{
-		user:         user,
-		changeLog:    changeLog,
-		urlRetriever: urlRetriever,
+		authToken:     authToken,
+		authenticator: authenticator,
+		changeLog:     changeLog,
+		urlRetriever:  urlRetriever,
 	}
 }

--- a/backend/app/adapter/graphql/resolver/authquery_test.go
+++ b/backend/app/adapter/graphql/resolver/authquery_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/short-d/short/app/usecase/auth"
+
 	"github.com/short-d/app/mdtest"
 	"github.com/short-d/short/app/adapter/db"
 	"github.com/short-d/short/app/adapter/graphql/scalar"
@@ -100,7 +102,14 @@ func TestAuthQuery_URL(t *testing.T) {
 			changeLogRepo := db.NewChangeLogSQL(sqlDB)
 			changeLog := changelog.NewPersist(keyGen, timerFake, changeLogRepo)
 
-			query := newAuthQuery(&testCase.user, changeLog, retrieverFake)
+			tokenizer := mdtest.NewCryptoTokenizerFake()
+			timer := mdtest.NewTimerFake(time.Now())
+			authenticator := auth.NewAuthenticator(tokenizer, timer, time.Hour)
+
+			authToken, err := authenticator.GenerateToken(testCase.user)
+			mdtest.Equal(t, nil, err)
+
+			query := newAuthQuery(&authToken, authenticator, changeLog, retrieverFake)
 
 			urlArgs := &URLArgs{
 				Alias:       testCase.alias,

--- a/backend/app/adapter/graphql/resolver/error.go
+++ b/backend/app/adapter/graphql/resolver/error.go
@@ -115,7 +115,7 @@ func (e ErrInvalidCustomAlias) Error() string {
 }
 
 // ErrInvalidAuthToken signifies the provided authentication is invalid.
-type ErrInvalidAuthToken string
+type ErrInvalidAuthToken struct{}
 
 var _ GraphQlError = (*ErrInvalidAuthToken)(nil)
 
@@ -123,8 +123,7 @@ var _ GraphQlError = (*ErrInvalidAuthToken)(nil)
 // handle the error.
 func (e ErrInvalidAuthToken) Extensions() map[string]interface{} {
 	return map[string]interface{}{
-		"code":      ErrCodeInvalidAuthToken,
-		"authToken": string(e),
+		"code": ErrCodeInvalidAuthToken,
 	}
 }
 

--- a/backend/app/adapter/graphql/resolver/mutation.go
+++ b/backend/app/adapter/graphql/resolver/mutation.go
@@ -36,12 +36,7 @@ func (m Mutation) AuthMutation(args *AuthMutationArgs) (*AuthMutation, error) {
 		return nil, ErrNotHuman{}
 	}
 
-	user, err := viewer(args.AuthToken, m.authenticator)
-	if err != nil {
-		return nil, err
-	}
-
-	authMutation := newAuthMutation(user, m.changeLog, m.urlCreator)
+	authMutation := newAuthMutation(args.AuthToken, m.authenticator, m.changeLog, m.urlCreator)
 	return &authMutation, nil
 }
 

--- a/backend/app/adapter/graphql/resolver/query.go
+++ b/backend/app/adapter/graphql/resolver/query.go
@@ -23,12 +23,7 @@ type AuthQueryArgs struct {
 
 // AuthQuery extracts user information from authentication token
 func (q Query) AuthQuery(args *AuthQueryArgs) (*AuthQuery, error) {
-	user, err := viewer(args.AuthToken, q.authenticator)
-	if err != nil {
-		return nil, err
-	}
-
-	authQuery := newAuthQuery(user, q.changeLog, q.urlRetriever)
+	authQuery := newAuthQuery(args.AuthToken, q.authenticator, q.changeLog, q.urlRetriever)
 	return &authQuery, nil
 }
 

--- a/backend/app/adapter/graphql/resolver/query_test.go
+++ b/backend/app/adapter/graphql/resolver/query_test.go
@@ -44,7 +44,7 @@ func TestQuery_AuthQuery(t *testing.T) {
 		{
 			name:      "with invalid auth token",
 			authToken: &randomToken,
-			expHasErr: true,
+			expHasErr: false,
 		},
 		{
 			name:      "without auth token",
@@ -79,13 +79,12 @@ func TestQuery_AuthQuery(t *testing.T) {
 
 			mdtest.Equal(t, nil, err)
 			authQueryArgs := AuthQueryArgs{AuthToken: testCase.authToken}
-			authQuery, err := query.AuthQuery(&authQueryArgs)
+			_, err = query.AuthQuery(&authQueryArgs)
 			if testCase.expHasErr {
 				mdtest.NotEqual(t, nil, err)
 				return
 			}
 			mdtest.Equal(t, nil, err)
-			mdtest.Equal(t, testCase.expUser, authQuery.user)
 		})
 	}
 }

--- a/backend/app/adapter/graphql/resolver/viewer.go
+++ b/backend/app/adapter/graphql/resolver/viewer.go
@@ -1,15 +1,16 @@
 package resolver
 
 import (
+	"errors"
+
 	"github.com/short-d/short/app/entity"
 	"github.com/short-d/short/app/usecase/auth"
 )
 
-func viewer(authToken *string, authenticator auth.Authenticator) (*entity.User, error) {
+func viewer(authToken *string, authenticator auth.Authenticator) (entity.User, error) {
 	if authToken == nil {
-		return nil, nil
+		return entity.User{}, errors.New("auth token can't be empty")
 	}
 
-	user, err := authenticator.GetUser(*authToken)
-	return &user, err
+	return authenticator.GetUser(*authToken)
 }

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -231,8 +231,8 @@ export class Home extends Component<Props, State> {
         );
         this.copyShortenedLink(shortLink);
       })
-      .catch(({ authorizationErr, createShortLinkErr }) => {
-        if (authorizationErr) {
+      .catch(({ authenticationErr, createShortLinkErr }) => {
+        if (authenticationErr) {
           this.requestSignIn();
           return;
         }

--- a/frontend/src/service/Captcha.service.ts
+++ b/frontend/src/service/Captcha.service.ts
@@ -34,7 +34,7 @@ export class CaptchaService {
       this.reCaptcha.execute(action).then(resolve, err => {
         const errMsg = err.message;
         if (CaptchaService.contains(errMsg, INVALID_SITE_KEY_ERR_MSG)) {
-          reject(Err.InvalidRecaptchaSiteKey);
+          reject(Err.InvalidReCaptchaSiteKey);
           return;
         }
         reject(Err.Unknown);

--- a/frontend/src/service/Error.service.ts
+++ b/frontend/src/service/Error.service.ts
@@ -5,7 +5,7 @@ export enum Err {
   InvalidReCaptchaSiteKey = 'invalidReCaptchaSiteKey',
   AliasAlreadyExist = 'aliasAlreadyExist',
   UserNotHuman = 'requesterNotHuman',
-  Unauthorized = 'invalidAuthToken',
+  Unauthenticated = 'invalidAuthToken',
   NetworkError = 'networkError',
   Unknown = 'unknownError'
 }

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -84,9 +84,9 @@ export class UrlService {
         resolve(url);
         return;
       } catch (errCode) {
-        if (errCode === Err.Unauthorized) {
+        if (errCode === Err.Unauthenticated) {
           reject({
-            authorizationErr: 'Unauthorized to create short link'
+            authenticationErr: 'User is not authenticated'
           });
           return;
         }


### PR DESCRIPTION
Part of fix for #623.

## Current Behavior ( Optional for new feature )
### Description
Users were promoted with `unknown error` after their authentication token expired. Frustrated users have no clue how to fix this error and cannot create new short links.

### Screenshots
<img width="771" alt="Screen Shot 2020-04-07 at 10 21 13 PM" src="https://user-images.githubusercontent.com/3537801/78753904-77484100-792b-11ea-9d58-d3ff501a39e7.png">

## New Behavior
### Description
Users are now promoted to sign in after their auth token expired.

### Screenshots
<img width="1247" alt="Screen Shot 2020-04-07 at 11 58 47 PM" src="https://user-images.githubusercontent.com/3537801/78754109-c9896200-792b-11ea-873f-7c2bbbf557b6.png">

