### PR TITLE
Add UpdateURL to graphql schema and resolvers

### DIFF
--- a/backend/app/adapter/gqlapi/api_test.go
+++ b/backend/app/adapter/gqlapi/api_test.go
@@ -50,7 +50,17 @@ func TestGraphQlAPI(t *testing.T) {
 		riskDetector,
 	)
 
-	s := requester.NewReCaptchaFake(requester.VerifyResponse{})
+	updater := url.NewUpdaterPersist(
+		&urlRepo,
+		&urlRelationRepo,
+		keyGen,
+		longLinkValidator,
+		customAliasValidator,
+		tm,
+		riskDetector,
+	)
+
+	s := external.NewReCaptchaFake(external.VerifyResponse{})
 	verifier := requester.NewVerifier(s)
 	auth := authenticator.NewAuthenticatorFake(time.Now(), time.Hour)
 

--- a/backend/app/adapter/gqlapi/api_test.go
+++ b/backend/app/adapter/gqlapi/api_test.go
@@ -60,7 +60,7 @@ func TestGraphQlAPI(t *testing.T) {
 		riskDetector,
 	)
 
-	s := external.NewReCaptchaFake(external.VerifyResponse{})
+	s := requester.NewReCaptchaFake(requester.VerifyResponse{})
 	verifier := requester.NewVerifier(s)
 	auth := authenticator.NewAuthenticatorFake(time.Now(), time.Hour)
 

--- a/backend/app/adapter/gqlapi/api_test.go
+++ b/backend/app/adapter/gqlapi/api_test.go
@@ -71,7 +71,7 @@ func TestGraphQlAPI(t *testing.T) {
 	changeLogRepo := repository.NewChangeLogFake([]entity.Change{})
 	userChangeLogRepo := repository.NewUserChangeLogFake(map[string]time.Time{})
 	changeLog := changelog.NewPersist(keyGen, tm, &changeLogRepo, &userChangeLogRepo)
-	r := resolver.NewResolver(lg, retriever, creator, changeLog, verifier, auth)
+	r := resolver.NewResolver(lg, retriever, creator, updater, changeLog, verifier, auth)
 	graphqlAPI := NewShort(r)
 	assert.Equal(t, true, graphql.IsGraphQlAPIValid(graphqlAPI))
 }

--- a/backend/app/adapter/gqlapi/resolver/authmutation.go
+++ b/backend/app/adapter/gqlapi/resolver/authmutation.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"errors"
 	"time"
 
 	"github.com/short-d/short/backend/app/adapter/gqlapi/scalar"
@@ -110,7 +109,7 @@ type UpdateURLArgs struct {
 
 func (u *URLInput) createUpdate() (*entity.URL, error) {
 	if u.isEmpty() {
-		return nil, errors.New("Empty Update")
+		return nil, ErrEmptyUpdate{}
 	}
 
 	return &entity.URL{

--- a/backend/app/adapter/gqlapi/resolver/authmutation.go
+++ b/backend/app/adapter/gqlapi/resolver/authmutation.go
@@ -78,7 +78,15 @@ func (a AuthMutation) CreateURL(args *CreateURLArgs) (*URL, error) {
 	}
 }
 
-func (a AuthMutation) UpdateURL(oldAlias string, urlInput URLInput, isPublic *bool) (*URL, error) {
+type UpdateURLArgs struct {
+	OldAlias string
+	Url      URLInput
+	IsPublic bool
+}
+
+func (a AuthMutation) UpdateURL(args *UpdateURLArgs) (*URL, error) {
+	oldAlias := args.OldAlias
+	urlInput := args.Url
 	user, err := viewer(a.authToken, a.authenticator)
 	if err != nil {
 		return nil, ErrInvalidAuthToken{}

--- a/backend/app/adapter/gqlapi/resolver/authmutation.go
+++ b/backend/app/adapter/gqlapi/resolver/authmutation.go
@@ -102,6 +102,7 @@ func (a AuthMutation) CreateURL(args *CreateURLArgs) (*URL, error) {
 	}
 }
 
+// UpdateURLArgs represents the possible parameters for updateURL endpoint
 type UpdateURLArgs struct {
 	OldAlias string
 	Url      URLInput
@@ -120,6 +121,7 @@ func (u *URLInput) createUpdate() (*entity.URL, error) {
 
 }
 
+// UpdateURL updates a short link mapping that belongs to a user
 func (a AuthMutation) UpdateURL(args *UpdateURLArgs) (*URL, error) {
 	user, err := viewer(a.authToken, a.authenticator)
 	if err != nil {

--- a/backend/app/adapter/gqlapi/resolver/error.go
+++ b/backend/app/adapter/gqlapi/resolver/error.go
@@ -12,6 +12,7 @@ const (
 	ErrCodeInvalidCustomAlias         = "invalidCustomAlias"
 	ErrCodeMaliciousContent           = "maliciousContent"
 	ErrCodeInvalidAuthToken           = "invalidAuthToken"
+	ErrCodeEmptyUpdate                = "emptyUpdate"
 )
 
 // GraphQlError represents a GraphAPI error.
@@ -150,4 +151,22 @@ func (e ErrMaliciousContent) Extensions() map[string]interface{} {
 // Error retrieves the human readable error message.
 func (e ErrMaliciousContent) Error() string {
 	return "contains malicious content"
+}
+
+// ErrEmptyUpdate signifies that input does not contain any URL fields to update.
+type ErrEmptyUpdate struct{}
+
+var _ GraphQlError = (*ErrEmptyUpdate)(nil)
+
+// Extensions keeps structured error metadata so that the clients can reliably
+// handle the error.
+func (e ErrEmptyUpdate) Extensions() map[string]interface{} {
+	return map[string]interface{}{
+		"code": ErrCodeEmptyUpdate,
+	}
+}
+
+// Error retrieves the human readable error message.
+func (e ErrEmptyUpdate) Error() string {
+	return "all input fields empty"
 }

--- a/backend/app/adapter/gqlapi/resolver/mutation.go
+++ b/backend/app/adapter/gqlapi/resolver/mutation.go
@@ -12,6 +12,7 @@ import (
 type Mutation struct {
 	logger            logger.Logger
 	urlCreator        url.Creator
+	urlUpdater        url.Updater
 	requesterVerifier requester.Verifier
 	authenticator     authenticator.Authenticator
 	changeLog         changelog.ChangeLog
@@ -35,7 +36,7 @@ func (m Mutation) AuthMutation(args *AuthMutationArgs) (*AuthMutation, error) {
 		return nil, ErrNotHuman{}
 	}
 
-	authMutation := newAuthMutation(args.AuthToken, m.authenticator, m.changeLog, m.urlCreator)
+	authMutation := newAuthMutation(args.AuthToken, m.authenticator, m.changeLog, m.urlCreator, m.urlUpdater)
 	return &authMutation, nil
 }
 
@@ -43,6 +44,7 @@ func newMutation(
 	logger logger.Logger,
 	changeLog changelog.ChangeLog,
 	urlCreator url.Creator,
+	urlUpdater url.Updater,
 	requesterVerifier requester.Verifier,
 	authenticator authenticator.Authenticator,
 ) Mutation {
@@ -50,6 +52,7 @@ func newMutation(
 		logger:            logger,
 		changeLog:         changeLog,
 		urlCreator:        urlCreator,
+		urlUpdater:        urlUpdater,
 		requesterVerifier: requesterVerifier,
 		authenticator:     authenticator,
 	}

--- a/backend/app/adapter/gqlapi/resolver/resolver.go
+++ b/backend/app/adapter/gqlapi/resolver/resolver.go
@@ -20,6 +20,7 @@ func NewResolver(
 	urlRetriever url.Retriever,
 	urlCreator url.Creator,
 	changeLog changelog.ChangeLog,
+	urlUpdater url.Updater,
 	requesterVerifier requester.Verifier,
 	authenticator authenticator.Authenticator,
 ) Resolver {
@@ -29,6 +30,7 @@ func NewResolver(
 			logger,
 			changeLog,
 			urlCreator,
+			urlUpdater,
 			requesterVerifier,
 			authenticator,
 		),

--- a/backend/app/adapter/gqlapi/resolver/resolver.go
+++ b/backend/app/adapter/gqlapi/resolver/resolver.go
@@ -19,8 +19,8 @@ func NewResolver(
 	logger logger.Logger,
 	urlRetriever url.Retriever,
 	urlCreator url.Creator,
-	changeLog changelog.ChangeLog,
 	urlUpdater url.Updater,
+	changeLog changelog.ChangeLog,
 	requesterVerifier requester.Verifier,
 	authenticator authenticator.Authenticator,
 ) Resolver {

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -34,7 +34,7 @@ type Change {
 
 type AuthMutation {
 	createURL(url: URLInput!, isPublic: Boolean!): URL
-	updateURL(oldAlias: String!, url: URLInput!): URL
+	updateURL(oldAlias: String!, url: URLUpdateInput!): URL
 	createChange(change: ChangeInput!): Change!
 	viewChangeLog: Time!
 }
@@ -48,6 +48,12 @@ input URLInput {
 input ChangeInput {
   	title: String!
   	summaryMarkdown: String
+}
+
+input URLUpdateInput {
+	originalURL: String
+	customAlias: String
+	expireAt: Time
 }
 
 type URL {

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -34,6 +34,7 @@ type Change {
 
 type AuthMutation {
 	createURL(url: URLInput!, isPublic: Boolean!): URL
+	updateURL(oldAlias: String!, url: URLInput!): URL
 	createChange(change: ChangeInput!): Change!
 	viewChangeLog: Time!
 }

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -34,13 +34,13 @@ type Change {
 
 type AuthMutation {
 	createURL(url: URLInput!, isPublic: Boolean!): URL
-	updateURL(oldAlias: String!, url: URLUpdateInput!): URL
+	updateURL(oldAlias: String!, url: URLInput!): URL
 	createChange(change: ChangeInput!): Change!
 	viewChangeLog: Time!
 }
 
 input URLInput {
-	originalURL: String!
+	originalURL: String
 	customAlias: String
 	expireAt: Time
 }
@@ -48,12 +48,6 @@ input URLInput {
 input ChangeInput {
   	title: String!
   	summaryMarkdown: String
-}
-
-input URLUpdateInput {
-	originalURL: String
-	customAlias: String
-	expireAt: Time
 }
 
 type URL {

--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -73,7 +73,7 @@ WHERE "%s"=$5;`,
 		table.URL.ColumnOriginalURL,
 		table.URL.ColumnExpireAt,
 		table.URL.ColumnUpdatedAt,
-		oldAlias,
+		table.URL.ColumnAlias,
 	)
 
 	_, err := u.db.Exec(

--- a/backend/app/usecase/url/urlupdater.go
+++ b/backend/app/usecase/url/urlupdater.go
@@ -1,0 +1,95 @@
+package url
+
+import (
+	"github.com/short-d/app/fw/timer"
+	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/usecase/keygen"
+	"github.com/short-d/short/backend/app/usecase/repository"
+	"github.com/short-d/short/backend/app/usecase/risk"
+	"github.com/short-d/short/backend/app/usecase/validator"
+)
+
+var _ Updater = (*UpdaterPersist)(nil)
+
+type Updater interface {
+	UpdateURL(oldAlias string, update entity.URL, user entity.User) (entity.URL, error)
+}
+
+type UpdaterPersist struct {
+	urlRepo             repository.URL
+	userURLRelationRepo repository.UserURLRelation
+	keyGen              keygen.KeyGenerator
+	longLinkValidator   validator.LongLink
+	aliasValidator      validator.CustomAlias
+	timer               timer.Timer
+	riskDetector        risk.Detector
+}
+
+func (u UpdaterPersist) UpdateURL(
+	oldAlias string,
+	update entity.URL,
+	user entity.User,
+) (entity.URL, error) {
+	oldURL, err := u.urlRepo.GetByAlias(oldAlias)
+
+	if err != nil {
+		return entity.URL{}, err
+	}
+
+	update = u.updateAlias(oldURL, update)
+	update = u.updateLongLink(oldURL, update)
+
+	if u.riskDetector.IsURLMalicious(update.OriginalURL) {
+		return entity.URL{}, ErrMaliciousLongLink(update.OriginalURL)
+	}
+
+	if !u.aliasValidator.IsValid(&update.Alias) {
+		return entity.URL{}, ErrInvalidCustomAlias(oldAlias)
+	}
+
+	if !u.longLinkValidator.IsValid(&update.OriginalURL) {
+		return entity.URL{}, ErrInvalidLongLink(update.OriginalURL)
+	}
+
+	return u.urlRepo.UpdateURL(oldAlias, update)
+}
+
+func (u UpdaterPersist) updateAlias(url, update entity.URL) entity.URL {
+	newAlias := update.Alias
+
+	if newAlias == "" {
+		update.Alias = url.Alias
+	}
+
+	return update
+}
+
+func (u *UpdaterPersist) updateLongLink(url, update entity.URL) entity.URL {
+	newLongLink := update.OriginalURL
+
+	if newLongLink == "" {
+		url.OriginalURL = update.OriginalURL
+	}
+
+	return update
+}
+
+func NewUpdaterPersist(
+	urlRepo repository.URL,
+	userURLRelationRepo repository.UserURLRelation,
+	keyGen keygen.KeyGenerator,
+	longLinkValidator validator.LongLink,
+	aliasValidator validator.CustomAlias,
+	timer timer.Timer,
+	riskDetector risk.Detector,
+) UpdaterPersist {
+	return UpdaterPersist{
+		urlRepo,
+		userURLRelationRepo,
+		keyGen,
+		longLinkValidator,
+		aliasValidator,
+		timer,
+		riskDetector,
+	}
+}

--- a/backend/app/usecase/url/urlupdater.go
+++ b/backend/app/usecase/url/urlupdater.go
@@ -11,10 +11,12 @@ import (
 
 var _ Updater = (*UpdaterPersist)(nil)
 
+// Updater represents a short link attribute updater.
 type Updater interface {
 	UpdateURL(oldAlias string, update entity.URL, user entity.User) (entity.URL, error)
 }
 
+// CreatorPersist represents a short link updater that persists the given changes
 type UpdaterPersist struct {
 	urlRepo             repository.URL
 	userURLRelationRepo repository.UserURLRelation
@@ -25,6 +27,7 @@ type UpdaterPersist struct {
 	riskDetector        risk.Detector
 }
 
+// UpdateURL persists mutations for a given short link in the repository.
 func (u UpdaterPersist) UpdateURL(
 	oldAlias string,
 	update entity.URL,
@@ -74,6 +77,7 @@ func (u *UpdaterPersist) updateLongLink(url, update entity.URL) entity.URL {
 	return url
 }
 
+// NewUpdaterPersist creates a new UpdaterPersist instance.
 func NewUpdaterPersist(
 	urlRepo repository.URL,
 	userURLRelationRepo repository.UserURLRelation,

--- a/backend/app/usecase/url/urlupdater.go
+++ b/backend/app/usecase/url/urlupdater.go
@@ -16,7 +16,7 @@ type Updater interface {
 	UpdateURL(oldAlias string, update entity.URL, user entity.User) (entity.URL, error)
 }
 
-// CreatorPersist represents a short link updater that persists the given changes
+// UpdaterPersist represents a short link updater that persists the given changes
 type UpdaterPersist struct {
 	urlRepo             repository.URL
 	userURLRelationRepo repository.UserURLRelation

--- a/backend/app/usecase/url/urlupdater.go
+++ b/backend/app/usecase/url/urlupdater.go
@@ -30,48 +30,48 @@ func (u UpdaterPersist) UpdateURL(
 	update entity.URL,
 	user entity.User,
 ) (entity.URL, error) {
-	oldURL, err := u.urlRepo.GetByAlias(oldAlias)
+	url, err := u.urlRepo.GetByAlias(oldAlias)
 
 	if err != nil {
 		return entity.URL{}, err
 	}
 
-	update = u.updateAlias(oldURL, update)
-	update = u.updateLongLink(oldURL, update)
+	url = u.updateAlias(url, update)
+	url = u.updateLongLink(url, update)
 
-	if u.riskDetector.IsURLMalicious(update.OriginalURL) {
-		return entity.URL{}, ErrMaliciousLongLink(update.OriginalURL)
+	if u.riskDetector.IsURLMalicious(url.OriginalURL) {
+		return entity.URL{}, ErrMaliciousLongLink(url.OriginalURL)
 	}
 
-	if !u.aliasValidator.IsValid(&update.Alias) {
-		return entity.URL{}, ErrInvalidCustomAlias(oldAlias)
+	if !u.aliasValidator.IsValid(&url.Alias) {
+		return entity.URL{}, ErrInvalidCustomAlias(url.Alias)
 	}
 
-	if !u.longLinkValidator.IsValid(&update.OriginalURL) {
-		return entity.URL{}, ErrInvalidLongLink(update.OriginalURL)
+	if !u.longLinkValidator.IsValid(&url.OriginalURL) {
+		return entity.URL{}, ErrInvalidLongLink(url.OriginalURL)
 	}
 
-	return u.urlRepo.UpdateURL(oldAlias, update)
+	return u.urlRepo.UpdateURL(oldAlias, url)
 }
 
 func (u UpdaterPersist) updateAlias(url, update entity.URL) entity.URL {
 	newAlias := update.Alias
 
-	if newAlias == "" {
-		update.Alias = url.Alias
+	if newAlias != "" {
+		url.Alias = newAlias
 	}
 
-	return update
+	return url
 }
 
 func (u *UpdaterPersist) updateLongLink(url, update entity.URL) entity.URL {
 	newLongLink := update.OriginalURL
 
-	if newLongLink == "" {
-		url.OriginalURL = update.OriginalURL
+	if newLongLink != "" {
+		url.OriginalURL = newLongLink
 	}
 
-	return update
+	return url
 }
 
 func NewUpdaterPersist(

--- a/backend/app/usecase/url/urlupdater_test.go
+++ b/backend/app/usecase/url/urlupdater_test.go
@@ -1,0 +1,143 @@
+// +build !integration all
+
+package url
+
+import (
+	"testing"
+	"time"
+
+	"github.com/short-d/app/fw/assert"
+	"github.com/short-d/app/fw/timer"
+	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/usecase/external"
+	"github.com/short-d/short/backend/app/usecase/keygen"
+	"github.com/short-d/short/backend/app/usecase/repository"
+	"github.com/short-d/short/backend/app/usecase/risk"
+	"github.com/short-d/short/backend/app/usecase/validator"
+)
+
+func TestURLUpdaterPersist_UpdateURL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	alias := "boGp9w35"
+	validNewAlias := "eBJRJJty"
+	validNewLongLink := "https://httpbin.org/get?p1=v1"
+
+	testCases := []struct {
+		name          string
+		alias         *string
+		availableKeys []external.Key
+		urls          urlMap
+		user          entity.User
+		urlUpdate     entity.URL
+		relationUsers []entity.User
+		relationURLs  []entity.URL
+		expHasErr     bool
+		expectedURL   entity.URL
+	}{
+		{
+			name:  "successfully update existing long link",
+			alias: &alias,
+			urls: urlMap{
+				"boGp9w35": entity.URL{
+					Alias:       "boGp9w35",
+					OriginalURL: "https://httpbin.org",
+				},
+			},
+			user: entity.User{
+				Email: "gopher@golang.org",
+			},
+			urlUpdate: entity.URL{
+				OriginalURL: validNewLongLink,
+			},
+			expHasErr: false,
+			expectedURL: entity.URL{
+				Alias:       "boGp9w35",
+				OriginalURL: validNewLongLink,
+			},
+		},
+		{
+			name:  "alias doesn't exist",
+			alias: &validNewAlias,
+			urls: urlMap{
+				"boGp9w35zzzz": entity.URL{
+					Alias:       "boGp9w35zzzz",
+					OriginalURL: "https://httpbin.org",
+				},
+			},
+			user: entity.User{
+				Email: "gopher@golang.org",
+			},
+			urlUpdate: entity.URL{
+				OriginalURL: validNewLongLink,
+			},
+			expHasErr:   true,
+			expectedURL: entity.URL{},
+		},
+		{
+			name:  "long link is invalid",
+			alias: &alias,
+			urls: urlMap{
+				"boGp9w35": entity.URL{
+					Alias:       "boGp9w35",
+					OriginalURL: "https://httpbin.org",
+				},
+			},
+			user: entity.User{
+				Email: "gopher@golang.org",
+			},
+			urlUpdate: entity.URL{
+				OriginalURL: "",
+			},
+			expHasErr:   true,
+			expectedURL: entity.URL{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			blockedHash := map[string]bool{}
+			tm := timer.NewStub(now)
+			urlRepo := repository.NewURLFake(testCase.urls)
+			userURLRepo := repository.NewUserURLRepoFake(
+				testCase.relationUsers,
+				testCase.relationURLs,
+			)
+			keyFetcher := external.NewKeyFetcherFake(testCase.availableKeys)
+			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)
+			assert.Equal(t, nil, err)
+			longLinkValidator := validator.NewLongLink()
+			aliasValidator := validator.NewCustomAlias()
+			blacklist := risk.NewBlackListFake(blockedHash)
+			riskDetector := risk.NewDetector(blacklist)
+			updater := NewUpdaterPersist(
+				&urlRepo,
+				&userURLRepo,
+				keyGen,
+				longLinkValidator,
+				aliasValidator,
+				tm,
+				riskDetector,
+			)
+
+			url, err := updater.UpdateURL(*testCase.alias, testCase.urlUpdate, testCase.user)
+			if testCase.expHasErr {
+				assert.NotEqual(t, nil, err)
+
+				_, err = urlRepo.GetByAlias(testCase.expectedURL.Alias)
+				assert.NotEqual(t, nil, err)
+
+				isExist := userURLRepo.IsRelationExist(testCase.user, testCase.expectedURL)
+				assert.Equal(t, false, isExist)
+				return
+			}
+			assert.Equal(t, nil, err)
+			assert.Equal(t, testCase.expectedURL.OriginalURL, url.OriginalURL)
+			assert.Equal(t, testCase.expectedURL.Alias, url.Alias)
+			assert.Equal(t, testCase.expectedURL.CreatedAt, url.CreatedAt)
+			assert.NotEqual(t, testCase.expectedURL.UpdatedAt, url.UpdatedAt)
+		})
+	}
+}

--- a/backend/app/usecase/url/urlupdater_test.go
+++ b/backend/app/usecase/url/urlupdater_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/short-d/app/fw/assert"
 	"github.com/short-d/app/fw/timer"
 	"github.com/short-d/short/backend/app/entity"
-	"github.com/short-d/short/backend/app/usecase/external"
 	"github.com/short-d/short/backend/app/usecase/keygen"
 	"github.com/short-d/short/backend/app/usecase/repository"
 	"github.com/short-d/short/backend/app/usecase/risk"
@@ -27,7 +26,7 @@ func TestURLUpdaterPersist_UpdateURL(t *testing.T) {
 	testCases := []struct {
 		name          string
 		alias         *string
-		availableKeys []external.Key
+		availableKeys []keygen.Key
 		urls          urlMap
 		user          entity.User
 		urlUpdate     entity.URL
@@ -88,7 +87,7 @@ func TestURLUpdaterPersist_UpdateURL(t *testing.T) {
 				Email: "gopher@golang.org",
 			},
 			urlUpdate: entity.URL{
-				OriginalURL: "",
+				OriginalURL: "aaaaaaaaaaaaaaaaaaa",
 			},
 			expHasErr:   true,
 			expectedURL: entity.URL{},
@@ -105,7 +104,7 @@ func TestURLUpdaterPersist_UpdateURL(t *testing.T) {
 				testCase.relationUsers,
 				testCase.relationURLs,
 			)
-			keyFetcher := external.NewKeyFetcherFake(testCase.availableKeys)
+			keyFetcher := keygen.NewKeyFetcherFake(testCase.availableKeys)
 			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)
 			assert.Equal(t, nil, err)
 			longLinkValidator := validator.NewLongLink()

--- a/backend/dep/wire.go
+++ b/backend/dep/wire.go
@@ -159,6 +159,7 @@ func InjectGraphQLService(
 		wire.Bind(new(changelog.ChangeLog), new(changelog.Persist)),
 		wire.Bind(new(url.Retriever), new(url.RetrieverPersist)),
 		wire.Bind(new(url.Creator), new(url.CreatorPersist)),
+		wire.Bind(new(url.Updater), new(url.UpdaterPersist)),
 
 		observabilitySet,
 		authSet,
@@ -186,6 +187,7 @@ func InjectGraphQLService(
 		changelog.NewPersist,
 		url.NewRetrieverPersist,
 		url.NewCreatorPersist,
+		url.NewUpdaterPersist,
 		requester.NewVerifier,
 	)
 	return service.GraphQL{}, nil

--- a/backend/dep/wire_gen.go
+++ b/backend/dep/wire_gen.go
@@ -89,6 +89,7 @@ func InjectGraphQLService(runtime2 env.Runtime, prefix provider.LogPrefix, logLe
 	safeBrowsing := provider.NewSafeBrowsing(googleAPIKey, http)
 	detector := risk.NewDetector(safeBrowsing)
 	creatorPersist := url.NewCreatorPersist(urlSql, userURLRelationSQL, keyGenerator, longLink, customAlias, system, detector)
+	updaterPersist := url.NewUpdaterPersist(urlSql, userURLRelationSQL, keyGenerator, longLink, customAlias, system, detector)
 	changeLogSQL := sqldb.NewChangeLogSQL(sqlDB)
 	userChangeLogSQL := sqldb.NewUserChangeLogSQL(sqlDB)
 	persist := changelog.NewPersist(keyGenerator, system, changeLogSQL, userChangeLogSQL)

--- a/backend/dep/wire_gen.go
+++ b/backend/dep/wire_gen.go
@@ -7,7 +7,6 @@ package dep
 
 import (
 	"database/sql"
-
 	"github.com/google/wire"
 	"github.com/short-d/app/fw/analytics"
 	"github.com/short-d/app/fw/cli"
@@ -97,7 +96,7 @@ func InjectGraphQLService(runtime2 env.Runtime, prefix provider.LogPrefix, logLe
 	verifier := requester.NewVerifier(reCaptcha)
 	tokenizer := provider.NewJwtGo(jwtSecret)
 	authenticator := provider.NewAuthenticator(tokenizer, system, tokenValidDuration)
-	resolverResolver := resolver.NewResolver(loggerLogger, retrieverPersist, creatorPersist, persist, verifier, authenticator)
+	resolverResolver := resolver.NewResolver(loggerLogger, retrieverPersist, creatorPersist, updaterPersist, persist, verifier, authenticator)
 	api := gqlapi.NewShort(resolverResolver)
 	graphGopherHandler := graphql.NewGraphGopherHandler(api)
 	graphQL := provider.NewGraphQLService(graphqlPath, graphGopherHandler, loggerLogger)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -342,6 +342,7 @@ github.com/short-d/kgs v0.0.0-20200419183416-2deb6aa8d7ed h1:goDxEfMeotHFO2J8cg5
 github.com/short-d/kgs v0.0.0-20200419183416-2deb6aa8d7ed/go.mod h1:b0Uw5WfhgcBsheLrDNm8RO0lb4C5UggG+WzBe4rxn7U=
 github.com/short-d/kgs v0.0.0-20200505215800-7d538f015ea1 h1:a75oDPkkATM03ONinwZDshyqA9L5WXFw4PH0+YcWW/w=
 github.com/short-d/kgs v0.0.0-20200505215800-7d538f015ea1/go.mod h1:b0Uw5WfhgcBsheLrDNm8RO0lb4C5UggG+WzBe4rxn7U=
+github.com/short-d/short v0.0.0-20200519020837-bc5d6e75c393 h1:0bb5FRcuamv2iJ5WnEVeF74GTSuxfEnMSprB1Wj96/4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -210,8 +210,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.4.0 h1:TmtCFbH+Aw0AixwyttznSMQDgbR5Yed/Gg6S8Funrhc=
-github.com/lib/pq v1.4.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.5.2 h1:yTSXVswvWUOQ3k1sd7vJfDrbSl8lKuscqFJRqjC0ifw=
 github.com/lib/pq v1.5.2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -314,8 +312,6 @@ github.com/rogpeppe/go-internal v1.4.0 h1:LUa41nrWTQNGhzdsZ5lTnkwbNjj6rXTdazA1cS
 github.com/rogpeppe/go-internal v1.4.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rubenv/sql-migrate v0.0.0-20190902133344-8926f37f0bc1 h1:G7j/gxkXAL80NMLOWi6EEctDET1Iuxl3sBMJXDnu2z0=
 github.com/rubenv/sql-migrate v0.0.0-20190902133344-8926f37f0bc1/go.mod h1:WS0rl9eEliYI8DPnr3TOwz4439pay+qNgzJoVya/DmY=
-github.com/rubenv/sql-migrate v0.0.0-20200402132117-435005d389bc h1:+2DdDcxVYlarHjYcZTt8dZ4Ec8cXZirzL5ko0mkKPjU=
-github.com/rubenv/sql-migrate v0.0.0-20200402132117-435005d389bc/go.mod h1:DCgfY80j8GYL7MLEfvcpSFvjD0L5yZq/aZUJmhZklyg=
 github.com/rubenv/sql-migrate v0.0.0-20200429072036-ae26b214fa43 h1:0i6uTtxUGc/jpK/CngM4T2S2NFnqYUUxH+lKDgBLw8U=
 github.com/rubenv/sql-migrate v0.0.0-20200429072036-ae26b214fa43/go.mod h1:DCgfY80j8GYL7MLEfvcpSFvjD0L5yZq/aZUJmhZklyg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -338,11 +334,8 @@ github.com/short-d/eventbus v0.0.0-20200105092235-2dfc4be1f9ee h1:LNafZ4caEAcTlg
 github.com/short-d/eventbus v0.0.0-20200105092235-2dfc4be1f9ee/go.mod h1:S3Nww0QNubrzHbWTpfzAg8YQLwXuM9GH2cGshOU6GJQ=
 github.com/short-d/eventbus v0.0.0-20200515152349-a8a7cb883a47 h1:Goj2PHNcRwk2CYxuQdyG7983FnP6HYovFlvoY7QjBz8=
 github.com/short-d/eventbus v0.0.0-20200515152349-a8a7cb883a47/go.mod h1:S3Nww0QNubrzHbWTpfzAg8YQLwXuM9GH2cGshOU6GJQ=
-github.com/short-d/kgs v0.0.0-20200419183416-2deb6aa8d7ed h1:goDxEfMeotHFO2J8cg5JDA5aoGULS6Ov9xr2SaGjb7c=
-github.com/short-d/kgs v0.0.0-20200419183416-2deb6aa8d7ed/go.mod h1:b0Uw5WfhgcBsheLrDNm8RO0lb4C5UggG+WzBe4rxn7U=
 github.com/short-d/kgs v0.0.0-20200505215800-7d538f015ea1 h1:a75oDPkkATM03ONinwZDshyqA9L5WXFw4PH0+YcWW/w=
 github.com/short-d/kgs v0.0.0-20200505215800-7d538f015ea1/go.mod h1:b0Uw5WfhgcBsheLrDNm8RO0lb4C5UggG+WzBe4rxn7U=
-github.com/short-d/short v0.0.0-20200519020837-bc5d6e75c393 h1:0bb5FRcuamv2iJ5WnEVeF74GTSuxfEnMSprB1Wj96/4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -436,8 +429,6 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200421231249-e086a090c8fd h1:QPwSajcTUrFriMF1nJ3XzgoqakqQEsnZf9LdXdi2nkI=
-golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -467,8 +458,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -509,8 +498,6 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb h1:nAFaltAMbNVA0rixtwvdnqgSVLX3HFUUvMkEklmzbYM=
-google.golang.org/genproto v0.0.0-20200420144010-e5e8543f8aeb/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587 h1:1Ym+vvUpq1ZHvxzn34gENJX8U4aKO+vhy2P/2+Xl6qQ=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
@@ -525,8 +512,6 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.29.0 h1:2pJjwYOdkZ9HlN4sWRYBg9ttH5bCOlsueaM+b/oYjwo=
-google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
* Update GraphQL Schema's AuthMutation to include `updateURL`.

* Refactor to use single `UrlInput` in both `updateURL` and `createURL`.

* Regenerate wired dependencies.