### PR TITLE
Refrain PageControl mount from triggering onPageChanged event

### DIFF
--- a/frontend/src/component/ui/PageControl.tsx
+++ b/frontend/src/component/ui/PageControl.tsx
@@ -26,7 +26,9 @@ export class PageControl extends Component<IProps, IStates> {
   }
 
   componentDidMount(): void {
-    this.showPage(0);
+    this.setState({
+      currentPageIdx: 0
+    });
   }
 
   render() {


### PR DESCRIPTION
Fixes #661 

## Current Behavior ( Optional for new feature )
### Description
The pageControl had the responsibility of fetching the initial data.

## New Behavior
### Description
Moving the responsibility of fetching the initial data to it's parent as in some cases, the pageControl would not be even required to be mounted or rendered if no initial data exists.