### PR TITLE
Fix memory leak warning in toast unit tests

### DIFF
--- a/frontend/src/component/ui/Toast.spec.tsx
+++ b/frontend/src/component/ui/Toast.spec.tsx
@@ -7,6 +7,10 @@ describe('Toast component', () => {
     jest.useFakeTimers();
   });
 
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
   test('should render without crash', () => {
     render(<Toast />);
   });
@@ -36,8 +40,6 @@ describe('Toast component', () => {
 
     jest.advanceTimersByTime(HALF_TIME);
     expect(container.textContent).not.toContain(toastMessage);
-
-    jest.clearAllTimers();
   });
 
   test('second notify call should replace first toast', () => {
@@ -62,7 +64,5 @@ describe('Toast component', () => {
 
     jest.advanceTimersByTime(HALF_TIME);
     expect(container.textContent).not.toContain(secondToastMessage);
-
-    jest.clearAllTimers();
   });
 });


### PR DESCRIPTION
Fixes #663 

## New Behavior
### Description
One of the tests didn't have `ckearAllTimers` which made the Toast component to call `hide` after the component was unmounted from the test.
Also, added `clearAllTimers` in `afterEach` method to remove non test related(AAA) code in each tests.