### PR TITLE
Retyle user short links section

### DIFF
--- a/frontend/src/component/pages/Home.scss
+++ b/frontend/src/component/pages/Home.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  .user-short-links-section {
+    margin-top: 20px;
+  }
+
   @include respond-to($phone) {
     .title {
       text-align: center;

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -20,8 +20,8 @@ import { Store } from 'redux';
 import {
   clearError,
   raiseCreateShortLinkError,
-  raiseInputError,
   raiseGetUserShortLinksError,
+  raiseInputError,
   updateAlias,
   updateCreatedUrl,
   updateLongLink
@@ -336,11 +336,14 @@ export class Home extends Component<Props, State> {
             onShortLinkTextFieldChange={this.handleAliasChange}
             onCreateShortLinkButtonClick={this.handleCreateShortLinkClick}
           />
-          {this.state.isUserSignedIn &&
-            this.props.uiFactory.createUserShortLinksSection({
-              onPageLoad: this.handleOnShortLinkPageLoad,
-              pagedShortLinks: this.state.currentPagedShortLinks
-            })}
+          {this.state.isUserSignedIn && (
+            <div className={'user-short-links-section'}>
+              {this.props.uiFactory.createUserShortLinksSection({
+                onPageLoad: this.handleOnShortLinkPageLoad,
+                pagedShortLinks: this.state.currentPagedShortLinks
+              })}
+            </div>
+          )}
         </div>
         <Footer
           uiFactory={this.props.uiFactory}

--- a/frontend/src/component/pages/shared/UserShortLinksSection.scss
+++ b/frontend/src/component/pages/shared/UserShortLinksSection.scss
@@ -1,0 +1,13 @@
+@import '../../styles/dimension';
+
+.UserShortLinksSection {
+  width: $content-width;
+  margin-left: auto;
+  margin-right: auto;
+
+  .page-control-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+  }
+}

--- a/frontend/src/component/pages/shared/UserShortLinksSection.spec.tsx
+++ b/frontend/src/component/pages/shared/UserShortLinksSection.spec.tsx
@@ -18,15 +18,17 @@ describe('UserShortLinksSection component', () => {
       <UserShortLinksSection onPageLoad={jest.fn} />
     );
 
-    expect(container.textContent).not.toContain('Created Short Links');
-    expect(container.textContent).not.toContain('Long URL');
+    expect(container.textContent).not.toContain('Favorites');
+    expect(container.textContent).not.toContain('Long Link');
     expect(container.textContent).not.toContain('Alias');
   });
 
   test('should render nothing when there is 0 total pages', () => {
     const pagedShortLinks: IPagedShortLinks = {
       shortLinks: [],
-      totalCount: 0
+      totalCount: 0,
+      offset: 0,
+      pageSize: 0
     };
 
     const { container } = render(
@@ -36,15 +38,17 @@ describe('UserShortLinksSection component', () => {
       />
     );
 
-    expect(container.textContent).not.toContain('Created Short Links');
-    expect(container.textContent).not.toContain('Long URL');
+    expect(container.textContent).not.toContain('Favorites');
+    expect(container.textContent).not.toContain('Long Link');
     expect(container.textContent).not.toContain('Alias');
   });
 
   test('should render correctly when given at least 1 page', () => {
     const pagedShortLinks: IPagedShortLinks = {
       shortLinks: [],
-      totalCount: 1
+      totalCount: 1,
+      offset: 0,
+      pageSize: 0
     };
 
     const { container } = render(
@@ -54,8 +58,8 @@ describe('UserShortLinksSection component', () => {
       />
     );
 
-    expect(container.textContent).toContain('Created Short Links');
-    expect(container.textContent).toContain('Long URL');
+    expect(container.textContent).toContain('Favorites');
+    expect(container.textContent).toContain('Long Link');
     expect(container.textContent).toContain('Alias');
   });
 
@@ -66,7 +70,9 @@ describe('UserShortLinksSection component', () => {
         { originalUrl: 'https://longurl.com/2', alias: 'alias2' },
         { originalUrl: 'https://longurl.com/3', alias: 'alias3' }
       ],
-      totalCount: 12
+      totalCount: 12,
+      offset: 0,
+      pageSize: 0
     };
 
     const { container } = render(
@@ -76,8 +82,8 @@ describe('UserShortLinksSection component', () => {
       />
     );
 
-    expect(container.textContent).toContain('Created Short Links');
-    expect(container.textContent).toContain('Long URL');
+    expect(container.textContent).toContain('Favorites');
+    expect(container.textContent).toContain('Long Link');
     expect(container.textContent).toContain('Alias');
 
     for (let urlIdx = 0; urlIdx < pagedShortLinks.shortLinks.length; urlIdx++) {
@@ -94,7 +100,9 @@ describe('UserShortLinksSection component', () => {
         { originalUrl: 'https://longurl.com/2', alias: 'alias2' },
         { originalUrl: 'https://longurl.com/3', alias: 'alias3' }
       ],
-      totalCount: 3
+      totalCount: 3,
+      offset: 0,
+      pageSize: 0
     };
     const pageSize = 5;
 
@@ -119,7 +127,9 @@ describe('UserShortLinksSection component', () => {
         { originalUrl: 'https://longurl.com/4', alias: 'alias4' },
         { originalUrl: 'https://longurl.com/5', alias: 'alias5' }
       ],
-      totalCount: 5
+      totalCount: 5,
+      offset: 0,
+      pageSize: 0
     };
 
     const { container } = render(
@@ -156,7 +166,9 @@ describe('UserShortLinksSection component', () => {
         { originalUrl: 'https://longurl.com/2', alias: 'alias2' },
         { originalUrl: 'https://longurl.com/3', alias: 'alias3' }
       ],
-      totalCount: 12
+      totalCount: 12,
+      offset: 0,
+      pageSize: 0
     };
 
     let rerender: any;
@@ -213,7 +225,9 @@ describe('UserShortLinksSection component', () => {
             pageSize={pageSize}
             pagedShortLinks={{
               shortLinks: shortLinks.slice(offset, pageSize),
-              totalCount: shortLinks.length
+              totalCount: shortLinks.length,
+              offset: 0,
+              pageSize: 0
             }}
           />
         );
@@ -226,7 +240,9 @@ describe('UserShortLinksSection component', () => {
         pageSize={pageSize}
         pagedShortLinks={{
           shortLinks: shortLinks.slice(0, pageSize),
-          totalCount: shortLinks.length
+          totalCount: shortLinks.length,
+          offset: 0,
+          pageSize: 0
         }}
       />
     );

--- a/frontend/src/component/pages/shared/UserShortLinksSection.tsx
+++ b/frontend/src/component/pages/shared/UserShortLinksSection.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-
-import { Section } from '../../ui/Section';
 import { PageControl } from '../../ui/PageControl';
 import { Table } from '../../ui/Table';
 import { Url } from '../../../entity/Url';
 import { IPagedShortLinks } from '../../../service/ShortLink.service';
+import './UserShortLinksSection.scss';
+import { Section } from '../../ui/Section';
 
 interface IProps {
   pagedShortLinks?: IPagedShortLinks;
@@ -33,16 +33,18 @@ export class UserShortLinksSection extends Component<IProps> {
     }
 
     return (
-      <div>
-        <Section title={'Created Short Links'}>
+      <div className={'UserShortLinksSection'}>
+        <Section title={'Favorites'}>
           <Table
-            headers={['Long URL', 'Alias']}
+            headers={['Long Link', 'Alias']}
             rows={this.createTableRows()}
           />
-          <PageControl
-            totalPages={this.calculateTotalPages()}
-            onPageChanged={this.onPageChanged}
-          />
+          <div className={'page-control-wrapper'}>
+            <PageControl
+              totalPages={this.calculateTotalPages()}
+              onPageChanged={this.onPageChanged}
+            />
+          </div>
         </Section>
       </div>
     );
@@ -59,7 +61,11 @@ export class UserShortLinksSection extends Component<IProps> {
   };
 
   private renderLongLink = (longLink: string) => {
-    return longLink;
+    return (
+      <a href={longLink} target="_blank" rel="noopener noreferrer">
+        {longLink}
+      </a>
+    );
   };
 
   private renderAlias = (alias: string) => {

--- a/frontend/src/component/ui/Table.scss
+++ b/frontend/src/component/ui/Table.scss
@@ -9,16 +9,51 @@
   @include round-corner;
 
   .table {
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 0 4px;
     width: 100%;
+    text-align: left;
 
-    th {
-      background-color: $color-table-header-background;
+    thead {
+      th {
+        padding: 10px 20px;
+        font-size: 14px;
+        color: #424242;
+        font-weight: $font-weight-semi-bold;
+      }
+
+      text-transform: uppercase;
     }
 
-    .table-cell {
-      padding: 5px;
-      text-align: left;
+    tbody {
+      tr {
+        td {
+          &:first-child {
+            @include round-corner;
+          }
+
+          &:last-child {
+            @include round-corner;
+          }
+
+          a {
+            text-decoration: none;
+            font-weight: $font-weight-semi-bold;
+            color: $color-dark-gray;
+            &:hover {
+              text-decoration: underline;
+            }
+          }
+
+          background-color: white;
+          padding: 12px 20px;
+          font-size: 14px;
+        }
+
+        &:not(:first-child) {
+          margin-top: 10px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Screenshots
<img width="1470" alt="Screen Shot 2020-04-25 at 7 12 58 PM" src="https://user-images.githubusercontent.com/3537801/80295588-ce6e5400-8728-11ea-923d-b9a803c7ba53.png">

## New Behavior
### Screenshots
<img width="1525" alt="Screen Shot 2020-04-25 at 7 10 09 PM" src="https://user-images.githubusercontent.com/3537801/80295574-aed72b80-8728-11ea-8338-5ba2c1104fef.png">

