### PR TITLE
Break long link into multiple lines

### DIFF
--- a/frontend/src/component/pages/shared/UserShortLinksSection.scss
+++ b/frontend/src/component/pages/shared/UserShortLinksSection.scss
@@ -10,4 +10,8 @@
     justify-content: center;
     margin-top: 20px;
   }
+
+  .long-link {
+    word-break: break-all;
+  }
 }

--- a/frontend/src/component/pages/shared/UserShortLinksSection.tsx
+++ b/frontend/src/component/pages/shared/UserShortLinksSection.tsx
@@ -62,7 +62,12 @@ export class UserShortLinksSection extends Component<IProps> {
 
   private renderLongLink = (longLink: string) => {
     return (
-      <a href={longLink} target="_blank" rel="noopener noreferrer">
+      <a
+        className={'long-link'}
+        href={longLink}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         {longLink}
       </a>
     );


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
When original url is too long, it stretches the table row and causes scrollbar to show up.

### Screenshots
<img width="1211" alt="Screen Shot 2020-04-25 at 8 17 57 PM" src="https://user-images.githubusercontent.com/3537801/80296682-ef877280-8731-11ea-8bd6-62bab876f1de.png">

## New Behavior
### Description
Long links are broken into multiple lines.

### Screenshots
<img width="1272" alt="Screen Shot 2020-04-25 at 8 19 31 PM" src="https://user-images.githubusercontent.com/3537801/80296711-1ba2f380-8732-11ea-8ad1-5864b6caccfd.png">
