### PR TITLE
Fix empty user ID for instrumentation

### DIFF
--- a/backend/app/usecase/instrumentation/instrumentation.go
+++ b/backend/app/usecase/instrumentation/instrumentation.go
@@ -14,48 +14,48 @@ type Instrumentation struct {
 	timer                           fw.Timer
 	metrics                         fw.Metrics
 	analytics                       fw.Analytics
-	ctx                             fw.ExecutionContext
 	ctxCh                           chan fw.ExecutionContext
-	redirectingAliasToLongLinkCh    chan struct{}
-	redirectedAliasToLongLinkCh     chan struct{}
-	longLinkRetrievalSucceedCh      chan struct{}
-	longLinkRetrievalFailedCh       chan struct{}
-	featureToggleRetrievalSucceedCh chan struct{}
-	featureToggleRetrievalFailedCh  chan struct{}
+	redirectingAliasToLongLinkCh    chan fw.ExecutionContext
+	redirectedAliasToLongLinkCh     chan fw.ExecutionContext
+	longLinkRetrievalSucceedCh      chan fw.ExecutionContext
+	longLinkRetrievalFailedCh       chan fw.ExecutionContext
+	featureToggleRetrievalSucceedCh chan fw.ExecutionContext
+	featureToggleRetrievalFailedCh  chan fw.ExecutionContext
+	madeFeatureDecisionCh           chan fw.ExecutionContext
 }
 
 // RedirectingAliasToLongLink tracks RedirectingAliasToLongLink event.
 func (i Instrumentation) RedirectingAliasToLongLink(user *entity.User) {
 	go func() {
-		<-i.redirectingAliasToLongLinkCh
-		userID := i.getUserID(user)
-		i.analytics.Track("RedirectingAliasToLongLink", map[string]string{}, userID, i.ctx)
+		ctx := <-i.redirectingAliasToLongLinkCh
+		userID := i.getUserID(user, ctx)
+		i.analytics.Track("RedirectingAliasToLongLink", map[string]string{}, userID, ctx)
 	}()
 }
 
 // RedirectedAliasToLongLink tracks RedirectedAliasToLongLink event.
 func (i Instrumentation) RedirectedAliasToLongLink(user *entity.User) {
 	go func() {
-		<-i.redirectedAliasToLongLinkCh
-		userID := i.getUserID(user)
-		i.analytics.Track("RedirectedAliasToLongLink", map[string]string{}, userID, i.ctx)
+		ctx := <-i.redirectedAliasToLongLinkCh
+		userID := i.getUserID(user, ctx)
+		i.analytics.Track("RedirectedAliasToLongLink", map[string]string{}, userID, ctx)
 	}()
 }
 
 // LongLinkRetrievalSucceed tracks the successes when retrieving long links.
 func (i Instrumentation) LongLinkRetrievalSucceed() {
 	go func() {
-		<-i.longLinkRetrievalSucceedCh
-		i.metrics.Count("long-link-retrieval-succeed", 1, 1, i.ctx)
+		ctx := <-i.longLinkRetrievalSucceedCh
+		i.metrics.Count("long-link-retrieval-succeed", 1, 1, ctx)
 	}()
 }
 
 // LongLinkRetrievalFailed tracks the failures when retrieving long links.
 func (i Instrumentation) LongLinkRetrievalFailed(err error) {
 	go func() {
-		<-i.longLinkRetrievalFailedCh
+		ctx := <-i.longLinkRetrievalFailedCh
 		i.logger.Error(err)
-		i.metrics.Count("long-link-retrieval-failed", 1, 1, i.ctx)
+		i.metrics.Count("long-link-retrieval-failed", 1, 1, ctx)
 	}()
 }
 
@@ -63,8 +63,8 @@ func (i Instrumentation) LongLinkRetrievalFailed(err error) {
 // of the feature toggle.
 func (i Instrumentation) FeatureToggleRetrievalSucceed() {
 	go func() {
-		<-i.featureToggleRetrievalSucceedCh
-		i.metrics.Count("feature-toggle-retrieval-succeed", 1, 1, i.ctx)
+		ctx := <-i.featureToggleRetrievalSucceedCh
+		i.metrics.Count("feature-toggle-retrieval-succeed", 1, 1, ctx)
 	}()
 }
 
@@ -72,9 +72,9 @@ func (i Instrumentation) FeatureToggleRetrievalSucceed() {
 // of the feature toggle.
 func (i Instrumentation) FeatureToggleRetrievalFailed(err error) {
 	go func() {
-		<-i.featureToggleRetrievalFailedCh
+		ctx := <-i.featureToggleRetrievalFailedCh
 		i.logger.Error(err)
-		i.metrics.Count("feature-toggle-retrieval-failed", 1, 1, i.ctx)
+		i.metrics.Count("feature-toggle-retrieval-failed", 1, 1, ctx)
 	}()
 }
 
@@ -84,13 +84,14 @@ func (i Instrumentation) MadeFeatureDecision(
 	isEnabled bool,
 ) {
 	go func() {
-		userID := i.getUserID(nil)
+		ctx := <-i.madeFeatureDecisionCh
+		userID := i.getUserID(nil, ctx)
 		isEnabledStr := fmt.Sprintf("%v", isEnabled)
 		props := map[string]string{
 			"feature-id": featureID,
 			"is-enabled": isEnabledStr,
 		}
-		i.analytics.Track("MadeFeatureDecision", props, userID, i.ctx)
+		i.analytics.Track("MadeFeatureDecision", props, userID, ctx)
 	}()
 }
 
@@ -104,9 +105,9 @@ func (i Instrumentation) Done() {
 	close(i.featureToggleRetrievalFailedCh)
 }
 
-func (i Instrumentation) getUserID(user *entity.User) string {
+func (i Instrumentation) getUserID(user *entity.User, ctx fw.ExecutionContext) string {
 	if user == nil {
-		return i.ctx.RequestID
+		return ctx.RequestID
 	}
 	return user.Email
 }
@@ -119,14 +120,15 @@ func NewInstrumentation(logger fw.Logger,
 	analytics fw.Analytics,
 	ctxCh chan fw.ExecutionContext,
 ) Instrumentation {
-	redirectingAliasToLongLinkCh := make(chan struct{})
-	redirectedAliasToLongLinkCh := make(chan struct{})
-	longLinkRetrievalSucceedCh := make(chan struct{})
-	longLinkRetrievalFailedCh := make(chan struct{})
-	featureToggleRetrievalSucceedCh := make(chan struct{})
-	featureToggleRetrievalFailedCh := make(chan struct{})
+	redirectingAliasToLongLinkCh := make(chan fw.ExecutionContext)
+	redirectedAliasToLongLinkCh := make(chan fw.ExecutionContext)
+	longLinkRetrievalSucceedCh := make(chan fw.ExecutionContext)
+	longLinkRetrievalFailedCh := make(chan fw.ExecutionContext)
+	featureToggleRetrievalSucceedCh := make(chan fw.ExecutionContext)
+	featureToggleRetrievalFailedCh := make(chan fw.ExecutionContext)
+	madeFeatureDecisionCh := make(chan fw.ExecutionContext)
 
-	ins := Instrumentation{
+	ins := &Instrumentation{
 		logger:                          logger,
 		tracer:                          tracer,
 		timer:                           timer,
@@ -139,17 +141,18 @@ func NewInstrumentation(logger fw.Logger,
 		longLinkRetrievalFailedCh:       longLinkRetrievalFailedCh,
 		featureToggleRetrievalSucceedCh: featureToggleRetrievalSucceedCh,
 		featureToggleRetrievalFailedCh:  featureToggleRetrievalFailedCh,
+		madeFeatureDecisionCh:           madeFeatureDecisionCh,
 	}
 	go func() {
 		ctx := <-ctxCh
-		ins.ctx = ctx
-		redirectingAliasToLongLinkCh <- struct{}{}
-		redirectedAliasToLongLinkCh <- struct{}{}
-		longLinkRetrievalSucceedCh <- struct{}{}
-		longLinkRetrievalFailedCh <- struct{}{}
-		featureToggleRetrievalSucceedCh <- struct{}{}
-		featureToggleRetrievalFailedCh <- struct{}{}
+		redirectingAliasToLongLinkCh <- ctx
+		redirectedAliasToLongLinkCh <- ctx
+		longLinkRetrievalSucceedCh <- ctx
+		longLinkRetrievalFailedCh <- ctx
+		featureToggleRetrievalSucceedCh <- ctx
+		featureToggleRetrievalFailedCh <- ctx
+		madeFeatureDecisionCh <- ctx
 		close(ctxCh)
 	}()
-	return ins
+	return *ins
 }


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Segment API throws empty user ID error. Segment stopped tracking user interactions. This is caused by ineffectively mutating ctx.

### Screenshots
<img width="715" alt="Screen Shot 2020-04-25 at 9 41 37 PM" src="https://user-images.githubusercontent.com/3537801/80298058-945b7d00-873d-11ea-9e9a-09611f41bab5.png">
<img width="843" alt="Screen Shot 2020-04-25 at 9 42 18 PM" src="https://user-images.githubusercontent.com/3537801/80298069-a9381080-873d-11ea-82ef-576c996dbb33.png">

## New Behavior
### Description
Segment is now anonymously tracking user actions again.
