### PR TITLE
Support switching to local logger under dev environment

### DIFF
--- a/backend/dep/provider/entryrepo.go
+++ b/backend/dep/provider/entryrepo.go
@@ -6,6 +6,8 @@ import (
 	"github.com/short-d/short/env"
 )
 
+// NewEntryRepositorySwitch swaps between different entry repository
+// implementations based on server environment.
 func NewEntryRepositorySwitch(
 	serverEnv fw.ServerEnv,
 	stdOut fw.StdOut,

--- a/backend/dep/provider/entryrepo.go
+++ b/backend/dep/provider/entryrepo.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"github.com/short-d/app/fw"
+	"github.com/short-d/app/modern/mdlogger"
+	"github.com/short-d/short/env"
+)
+
+func NewEntryRepositorySwitch(
+	serverEnv fw.ServerEnv,
+	stdOut fw.StdOut,
+	dataDogAPIKey DataDogAPIKey,
+	httpRequest fw.HTTPRequest,
+) mdlogger.EntryRepository {
+	if serverEnv == env.Development {
+		return mdlogger.NewLocal(stdOut)
+	}
+	return NewDataDogEntryRepo(dataDogAPIKey, httpRequest, serverEnv)
+}

--- a/backend/dep/wire.go
+++ b/backend/dep/wire.go
@@ -13,6 +13,7 @@ import (
 	"github.com/short-d/app/modern/mdenv"
 	"github.com/short-d/app/modern/mdgeo"
 	"github.com/short-d/app/modern/mdhttp"
+	"github.com/short-d/app/modern/mdio"
 	"github.com/short-d/app/modern/mdlogger"
 	"github.com/short-d/app/modern/mdmetrics"
 	"github.com/short-d/app/modern/mdnetwork"
@@ -42,18 +43,18 @@ import (
 
 var authSet = wire.NewSet(
 	provider.NewJwtGo,
-
 	provider.NewAuthenticator,
 )
 
 var observabilitySet = wire.NewSet(
+	wire.Bind(new(fw.StdOut), new(mdio.StdOut)),
 	wire.Bind(new(fw.Logger), new(mdlogger.Logger)),
-	wire.Bind(new(mdlogger.EntryRepository), new(mdlogger.DataDogEntryRepo)),
 	wire.Bind(new(fw.Metrics), new(mdmetrics.DataDog)),
 	wire.Bind(new(fw.Analytics), new(mdanalytics.Segment)),
 	wire.Bind(new(fw.Network), new(mdnetwork.Proxy)),
 
-	provider.NewDataDogEntryRepo,
+	mdio.NewBuildInStdOut,
+	provider.NewEntryRepositorySwitch,
 	provider.NewLogger,
 	mdtracer.NewLocal,
 	provider.NewDataDogMetrics,

--- a/backend/env/env.go
+++ b/backend/env/env.go
@@ -1,0 +1,10 @@
+package env
+
+import "github.com/short-d/app/fw"
+
+const (
+	Production  fw.ServerEnv = "production"
+	Staging     fw.ServerEnv = "staging"
+	Development fw.ServerEnv = "development"
+	Testing     fw.ServerEnv = "testing"
+)

--- a/backend/env/env.go
+++ b/backend/env/env.go
@@ -3,8 +3,12 @@ package env
 import "github.com/short-d/app/fw"
 
 const (
+	// Production implies the server is running under production environment.
 	Production  fw.ServerEnv = "production"
+	// Staging implies the server is running under staging environment.
 	Staging     fw.ServerEnv = "staging"
+	// Development implies the server is running on developers local machine.
 	Development fw.ServerEnv = "development"
+	// Testing implies the server is running under testing environment.
 	Testing     fw.ServerEnv = "testing"
 )

--- a/backend/env/env.go
+++ b/backend/env/env.go
@@ -4,11 +4,11 @@ import "github.com/short-d/app/fw"
 
 const (
 	// Production implies the server is running under production environment.
-	Production  fw.ServerEnv = "production"
+	Production fw.ServerEnv = "production"
 	// Staging implies the server is running under staging environment.
-	Staging     fw.ServerEnv = "staging"
+	Staging fw.ServerEnv = "staging"
 	// Development implies the server is running on developers local machine.
 	Development fw.ServerEnv = "development"
 	// Testing implies the server is running under testing environment.
-	Testing     fw.ServerEnv = "testing"
+	Testing fw.ServerEnv = "testing"
 )


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Developers are confused when they didn't see logs in the terminal during local development. Also, logging to DataDog has network latency.

## New Behavior
### Description
Switch to local logger when developing in local env.