### PR TITLE
Replace ID of anonymous user with hard-coded value

### DIFF
--- a/backend/app/adapter/routing/handle.go
+++ b/backend/app/adapter/routing/handle.go
@@ -22,10 +22,11 @@ func NewOriginalURL(
 	webFrontendURL netURL.URL,
 ) fw.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params fw.Params) {
-		i := instrumentationFactory.NewHTTP(r)
-		i.RedirectingAliasToLongLink(nil)
-
 		alias := params["alias"]
+
+		i := instrumentationFactory.NewHTTP(r)
+		i.RedirectingAliasToLongLink(alias)
+
 		now := timer.Now()
 		u, err := urlRetriever.GetURL(alias, &now)
 		if err != nil {
@@ -37,7 +38,7 @@ func NewOriginalURL(
 
 		originURL := u.OriginalURL
 		http.Redirect(w, r, originURL, http.StatusSeeOther)
-		i.RedirectedAliasToLongLink(nil)
+		i.RedirectedAliasToLongLink(u)
 	}
 }
 


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
We are running out of monthly free users on Segment. This is because each request is treated a independent user.
<img width="879" alt="Screen Shot 2020-04-28 at 5 05 40 PM" src="https://user-images.githubusercontent.com/3537801/80549592-8e9aad00-8972-11ea-9f37-6b7c9ba9efba.png">

## New Behavior
### Description
All anonymous users share the same user ID from now on. We also track the short link they visiting to potential monitor phishing attacks and to determine the hotspots in the short links.
