### PR TITLE
Reduce ip stack traffic

### DIFF
--- a/backend/app/adapter/db/url_integration_test.go
+++ b/backend/app/adapter/db/url_integration_test.go
@@ -259,7 +259,7 @@ func TestURLSql_UpdateURL(t *testing.T) {
 			name:     "alias not found",
 			oldAlias: "does_not_exist",
 			tableRows: []urlTableRow{
-				urlTableRow{
+				{
 					alias:     "220uFicCJj",
 					longLink:  "https://www.google.com",
 					createdAt: &createdAt,
@@ -272,12 +272,12 @@ func TestURLSql_UpdateURL(t *testing.T) {
 			name:     "alias is taken",
 			oldAlias: "220uFicCja",
 			tableRows: []urlTableRow{
-				urlTableRow{
+				{
 					alias:     "220uFicCJj",
 					longLink:  "https://www.google.com",
 					createdAt: &createdAt,
 				},
-				urlTableRow{
+				{
 					alias:     "efpIZ4OS",
 					longLink:  "https://gmail.com",
 					createdAt: &createdAt,
@@ -295,7 +295,7 @@ func TestURLSql_UpdateURL(t *testing.T) {
 				UpdatedAt:   &now,
 			},
 			tableRows: []urlTableRow{
-				urlTableRow{
+				{
 					alias:     "220uFicCJj",
 					longLink:  "https://www.google.com",
 					createdAt: &createdAt,

--- a/backend/app/adapter/google/safebrowsing.go
+++ b/backend/app/adapter/google/safebrowsing.go
@@ -3,9 +3,10 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/short-d/app/fw"
 	"github.com/short-d/short/app/usecase/risk"
-	"net/http"
 )
 
 var _ risk.BlackList = (*SafeBrowsing)(nil)

--- a/backend/app/adapter/routing/analytics/track.go
+++ b/backend/app/adapter/routing/analytics/track.go
@@ -1,0 +1,20 @@
+package analytics
+
+import (
+	"net/http"
+
+	"github.com/short-d/app/fw"
+	"github.com/short-d/short/app/adapter/request"
+)
+
+// TrackHandle records event happened in the API caller.
+func TrackHandle(instrumentationFactory request.InstrumentationFactory) fw.Handle {
+	return func(w http.ResponseWriter, r *http.Request, params fw.Params) {
+		i := instrumentationFactory.NewHTTP(r)
+
+		event := params["event"]
+		i.Track(event)
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/backend/app/adapter/routing/handle.go
+++ b/backend/app/adapter/routing/handle.go
@@ -89,7 +89,7 @@ func FeatureHandle(
 	featureDecisionMakerFactory feature.DecisionMakerFactory,
 ) fw.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params fw.Params) {
-		i := instrumentationFactory.NewHTTP(r)
+		i := instrumentationFactory.NewRequest()
 		featureID := params["featureID"]
 
 		decision := featureDecisionMakerFactory.NewDecision(i)

--- a/backend/app/adapter/routing/route.go
+++ b/backend/app/adapter/routing/route.go
@@ -3,6 +3,8 @@ package routing
 import (
 	netURL "net/url"
 
+	"github.com/short-d/short/app/adapter/routing/analytics"
+
 	"github.com/short-d/app/fw"
 	"github.com/short-d/short/app/adapter/facebook"
 	"github.com/short-d/short/app/adapter/github"
@@ -123,6 +125,11 @@ func NewShort(
 			Method: "GET",
 			Path:   "/features/:featureID",
 			Handle: FeatureHandle(instrumentationFactory, featureDecisionMakerFactory),
+		},
+		{
+			Method: "GET",
+			Path:   "/analytics/track/:event",
+			Handle: analytics.TrackHandle(instrumentationFactory),
 		},
 	}
 }

--- a/frontend/src/component/UIFactory.tsx
+++ b/frontend/src/component/UIFactory.tsx
@@ -21,6 +21,7 @@ import { ChangeLogService } from '../service/ChangeLog.service';
 import { IClipboardService } from '../service/clipboardService/Clipboard.service';
 import { ShortLinkService } from '../service/ShortLink.service';
 import { UserShortLinksSection } from './pages/shared/UserShortLinksSection';
+import { AnalyticsService } from '../service/Analytics.service';
 
 export class UIFactory {
   private ToggledGoogleSignInButton: ComponentType<any>;
@@ -42,7 +43,8 @@ export class UIFactory {
     private changeLogService: ChangeLogService,
     private store: Store<IAppState>,
     private featureDecisionService: IFeatureDecisionService,
-    private shortLinkService: ShortLinkService
+    private shortLinkService: ShortLinkService,
+    private analyticsService: AnalyticsService
   ) {
     const includeGoogleSignInButton = this.featureDecisionService.includeGoogleSignInButton();
     this.ToggledGoogleSignInButton = withFeatureToggle(
@@ -92,6 +94,7 @@ export class UIFactory {
         searchService={this.searchService}
         changeLogService={this.changeLogService}
         shortLinkService={this.shortLinkService}
+        analyticsService={this.analyticsService}
         store={this.store}
         location={location}
       />

--- a/frontend/src/component/pages/Home.tsx
+++ b/frontend/src/component/pages/Home.tsx
@@ -40,6 +40,7 @@ import {
   IPagedShortLinks,
   ShortLinkService
 } from '../../service/ShortLink.service';
+import { AnalyticsService } from '../../service/Analytics.service';
 
 interface Props {
   uiFactory: UIFactory;
@@ -53,6 +54,7 @@ interface Props {
   errorService: ErrorService;
   changeLogService: ChangeLogService;
   shortLinkService: ShortLinkService;
+  analyticsService: AnalyticsService;
   store: Store<IAppState>;
   location: Location;
 }
@@ -87,6 +89,7 @@ export class Home extends Component<Props, State> {
   }
 
   async componentDidMount() {
+    this.props.analyticsService.track('homePageLoad');
     this.setPromoDisplayStatus();
 
     this.props.authService.cacheAuthToken(this.props.location.search);

--- a/frontend/src/dep.ts
+++ b/frontend/src/dep.ts
@@ -20,6 +20,7 @@ import { ShortHTTPApi } from './service/ShortHTTP.api';
 import { DynamicDecisionService } from './service/feature-decision/DynamicDecision.service';
 import { ShortLinkService } from './service/ShortLink.service';
 import { ShortGraphQLApi } from './service/ShortGraphQL.api';
+import { AnalyticsService } from './service/Analytics.service';
 
 export function initEnvService(): EnvService {
   return new EnvService();
@@ -72,6 +73,7 @@ export function initUIFactory(
     shortGraphQLApiService,
     errorService
   );
+  const analyticsService = new AnalyticsService(shortHTTPApi);
 
   return new UIFactory(
     authService,
@@ -85,7 +87,8 @@ export function initUIFactory(
     changeLogService,
     store,
     dynamicDecisionService,
-    shortLinkService
+    shortLinkService,
+    analyticsService
   );
 }
 

--- a/frontend/src/service/Analytics.service.ts
+++ b/frontend/src/service/Analytics.service.ts
@@ -1,0 +1,9 @@
+import { ShortHTTPApi } from './ShortHTTP.api';
+
+export class AnalyticsService {
+  constructor(private shortHTTPApi: ShortHTTPApi) {}
+
+  track(event: string) {
+    this.shortHTTPApi.trackEvent(event).then();
+  }
+}

--- a/frontend/src/service/ShortHTTP.api.ts
+++ b/frontend/src/service/ShortHTTP.api.ts
@@ -15,4 +15,9 @@ export class ShortHTTPApi {
     const url = `${this.baseURL}/features/${featureID}`;
     return this.httpService.get<boolean>(url);
   }
+
+  trackEvent(event: string): Promise<void> {
+    const url = `${this.baseURL}/analytics/track/${event}`;
+    return this.httpService.get<void>(url);
+  }
 }


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Every call to feature decision API to reobtaining user's approximate GeoLocation. This is running out of IPStack quota.

<img width="778" alt="Screen Shot 2020-04-30 at 8 44 37 AM" src="https://user-images.githubusercontent.com/3537801/80730771-d9294000-8abe-11ea-9ed6-3dd057640a14.png">

## New Behavior
### Description
Only track user's approximate GeoLocation when Home page loads.
