### PR TITLE
Upgrade prettier to 1.19.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "@types/react-dom": "^16.9.1",
     "@types/react-router-dom": "^5.1.0",
     "node-sass": "^4.12.0",
-    "prettier": "1.18.2",
+    "prettier": "1.19.1",
     "react-scripts": "3.2.0",
     "stylelint": "^11.1.1",
     "stylelint-config-prettier": "^6.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8872,10 +8872,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
PRs #717 and #735 contain errors when running the script formatter due to use of optional chaining. Upgrading `prettier` to latest version fixes this. https://github.com/prettier/prettier/issues/7088