### PR TITLE
Generate random alias if empty alias provided

### DIFF
--- a/backend/app/usecase/url/urlcreator.go
+++ b/backend/app/usecase/url/urlcreator.go
@@ -68,7 +68,7 @@ func (c CreatorPersist) CreateURL(url entity.URL, customAlias *string, user enti
 		return entity.URL{}, ErrMaliciousLongLink(longLink)
 	}
 
-	if customAlias == nil || *customAlias == "" {
+	if !c.isAliasProvided(customAlias) {
 		return c.createURLWithAutoAlias(url, user)
 	}
 
@@ -76,6 +76,10 @@ func (c CreatorPersist) CreateURL(url entity.URL, customAlias *string, user enti
 		return entity.URL{}, ErrInvalidCustomAlias(*customAlias)
 	}
 	return c.createURLWithCustomAlias(url, *customAlias, user)
+}
+
+func (c CreatorPersist) isAliasProvided(customAlias *string) bool {
+	return customAlias != nil && *customAlias != ""
 }
 
 func (c CreatorPersist) createURLWithAutoAlias(url entity.URL, user entity.User) (entity.URL, error) {

--- a/backend/app/usecase/url/urlcreator.go
+++ b/backend/app/usecase/url/urlcreator.go
@@ -68,7 +68,7 @@ func (c CreatorPersist) CreateURL(url entity.URL, customAlias *string, user enti
 		return entity.URL{}, ErrMaliciousLongLink(longLink)
 	}
 
-	if customAlias == nil {
+	if customAlias == nil || *customAlias == "" {
 		return c.createURLWithAutoAlias(url, user)
 	}
 

--- a/backend/app/usecase/url/urlcreator_test.go
+++ b/backend/app/usecase/url/urlcreator_test.go
@@ -24,6 +24,7 @@ func TestURLCreatorPersist_CreateURL(t *testing.T) {
 
 	alias := "220uFicCJj"
 	longAlias := "an-alias-cannot-be-used-to-specify-default-arguments"
+	emptyAlias := ""
 
 	testCases := []struct {
 		name          string
@@ -93,17 +94,32 @@ func TestURLCreatorPersist_CreateURL(t *testing.T) {
 			},
 		},
 		{
-			name: "automatically generate alias",
-			urls: urlMap{
-				"220uFicCJj": entity.URL{
-					Alias:    "220uFicCJj",
-					ExpireAt: &now,
-				},
-			},
+			name: "automatically generate alias if null alias provided",
+			urls: urlMap{},
 			availableKeys: []external.Key{
 				"test",
 			},
 			alias: nil,
+			user: entity.User{
+				Email: "alpha@example.com",
+			},
+			url: entity.URL{
+				OriginalURL: "https://www.google.com",
+			},
+			expHasErr: false,
+			expectedURL: entity.URL{
+				Alias:       "test",
+				OriginalURL: "https://www.google.com",
+				CreatedAt:   &utc,
+			},
+		},
+		{
+			name: "automatically generate alias if empty string alias provided",
+			urls: urlMap{},
+			availableKeys: []external.Key{
+				"test",
+			},
+			alias: &emptyAlias,
 			user: entity.User{
 				Email: "alpha@example.com",
 			},

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -187,14 +187,12 @@ export class UrlService {
     link: Url,
     isPublic: boolean = false
   ) {
-    // TODO(issue#728) move alias input validation to backend
-    let alias = link.alias === '' ? null : link.alias!;
     return {
       captchaResponse: captchaResponse,
       authToken: this.authService.getAuthToken(),
       urlInput: {
         originalURL: link.originalUrl,
-        customAlias: alias
+        customAlias: link.alias
       },
       isPublic
     };


### PR DESCRIPTION
Fixes blank alias portion of #728. Currently just addresses empty aliases, TBD if malicious input for alias should also be handled. (edit: Will address in #744 to reduce scope of this PR)

## Current Behavior ( Optional for new feature )
### Description
Adding short link with alias set to empty string (not possible from frontend but GraphQL request can be crafted to have alias be set to empty string) will create entry with alias set to empty string.
### Screenshots
See #728.

## New Behavior
### Description
Now generates a random alias whenever empty string alias is passed. It should now be impossible to have a short link with alias of empty string.

### Screenshots
![image](https://user-images.githubusercontent.com/3276350/81121410-ad61ec00-8efc-11ea-8bcd-bccdef4d8896.png)

## TODO
- [ ] Determine if other edge case aliases should be included in this PR, including malicious strings (not malicious URLs as that's already taken care of)