### PR TITLE
Fix Page control index when total number of pages changes

### DIFF
--- a/frontend/src/component/ui/PageControl.spec.tsx
+++ b/frontend/src/component/ui/PageControl.spec.tsx
@@ -153,9 +153,7 @@ describe('PageControl component', () => {
     fireEvent.click(pageNumbers[8]);
     expect(currentPageIdx).toBe(8);
 
-    rerender(
-      <PageControl totalPages={5} onPageChanged={handlePageChanged} />
-    );
+    rerender(<PageControl totalPages={5} onPageChanged={handlePageChanged} />);
 
     const prevButton = container.querySelector('.previous');
     expect(prevButton).toBeTruthy();
@@ -181,9 +179,7 @@ describe('PageControl component', () => {
     fireEvent.click(pageNumbers[3]);
     expect(currentPageIdx).toBe(3);
 
-    rerender(
-      <PageControl totalPages={10} onPageChanged={handlePageChanged} />
-    );
+    rerender(<PageControl totalPages={10} onPageChanged={handlePageChanged} />);
 
     const prevButton = container.querySelector('.previous');
     expect(prevButton).toBeTruthy();

--- a/frontend/src/component/ui/PageControl.spec.tsx
+++ b/frontend/src/component/ui/PageControl.spec.tsx
@@ -137,10 +137,58 @@ describe('PageControl component', () => {
   });
 
   test('should fallback to last page if changing to page greater than total number of pages', () => {
-    fail('Not implemented');
+    let currentPageIdx = 0;
+    const handlePageChanged = (pageIdx: number) => {
+      currentPageIdx = pageIdx;
+    };
+
+    const { container, rerender } = render(
+      <PageControl totalPages={10} onPageChanged={handlePageChanged} />
+    );
+
+    const pageNumbers = container.querySelectorAll('.page-number');
+    fireEvent.click(pageNumbers[7]);
+    expect(currentPageIdx).toBe(7);
+
+    fireEvent.click(pageNumbers[8]);
+    expect(currentPageIdx).toBe(8);
+
+    rerender(
+      <PageControl totalPages={5} onPageChanged={handlePageChanged} />
+    );
+
+    const prevButton = container.querySelector('.previous');
+    expect(prevButton).toBeTruthy();
+    expect(prevButton!.textContent).toContain('Previous');
+    fireEvent.click(prevButton!);
+    expect(currentPageIdx).toBe(3);
   });
 
   test('should go to correct page after total number of pages changes', () => {
-    fail('Not implemented');
+    let currentPageIdx = 0;
+    const handlePageChanged = (pageIdx: number) => {
+      currentPageIdx = pageIdx;
+    };
+
+    const { container, rerender } = render(
+      <PageControl totalPages={5} onPageChanged={handlePageChanged} />
+    );
+
+    const pageNumbers = container.querySelectorAll('.page-number');
+    fireEvent.click(pageNumbers[4]);
+    expect(currentPageIdx).toBe(4);
+
+    fireEvent.click(pageNumbers[3]);
+    expect(currentPageIdx).toBe(3);
+
+    rerender(
+      <PageControl totalPages={10} onPageChanged={handlePageChanged} />
+    );
+
+    const prevButton = container.querySelector('.previous');
+    expect(prevButton).toBeTruthy();
+    expect(prevButton!.textContent).toContain('Previous');
+    fireEvent.click(prevButton!);
+    expect(currentPageIdx).toBe(2);
   });
 });

--- a/frontend/src/component/ui/PageControl.spec.tsx
+++ b/frontend/src/component/ui/PageControl.spec.tsx
@@ -135,4 +135,12 @@ describe('PageControl component', () => {
     fireEvent.click(nextButton!);
     expect(currentPageIdx).toBe(6);
   });
+
+  test('should fallback to last page if changing to page greater than total number of pages', () => {
+    fail('Not implemented');
+  });
+
+  test('should go to correct page after total number of pages changes', () => {
+    fail('Not implemented');
+  });
 });

--- a/frontend/src/component/ui/PageControl.tsx
+++ b/frontend/src/component/ui/PageControl.tsx
@@ -31,6 +31,15 @@ export class PageControl extends Component<IProps, IStates> {
     });
   }
 
+  componentWillReceiveProps(nextProps: IProps): void {
+    this.setState({
+      currentPageIdx: Math.min(
+        this.state.currentPageIdx,
+        nextProps.totalPages - 1
+      )
+    });
+  }
+
   render() {
     const { totalPages } = this.props;
 
@@ -130,10 +139,11 @@ export class PageControl extends Component<IProps, IStates> {
 
   private showPage(pageIdx: number) {
     const { onPageChanged } = this.props;
-    this.setState({ currentPageIdx: pageIdx });
-    if (!onPageChanged) {
-      return;
-    }
-    onPageChanged(pageIdx);
+    this.setState({ currentPageIdx: pageIdx }, () => {
+      if (!onPageChanged) {
+        return;
+      }
+      onPageChanged(pageIdx);
+    });
   }
 }

--- a/frontend/src/component/ui/PageControl.tsx
+++ b/frontend/src/component/ui/PageControl.tsx
@@ -25,18 +25,18 @@ export class PageControl extends Component<IProps, IStates> {
     };
   }
 
+  static getDerivedStateFromProps(props: IProps, state: IStates): IStates {
+    return {
+      currentPageIdx: Math.min(
+        state.currentPageIdx,
+        props.totalPages - 1
+      )
+    };
+  }
+
   componentDidMount(): void {
     this.setState({
       currentPageIdx: 0
-    });
-  }
-
-  componentWillReceiveProps(nextProps: IProps): void {
-    this.setState({
-      currentPageIdx: Math.min(
-        this.state.currentPageIdx,
-        nextProps.totalPages - 1
-      )
     });
   }
 

--- a/frontend/src/component/ui/PageControl.tsx
+++ b/frontend/src/component/ui/PageControl.tsx
@@ -27,10 +27,7 @@ export class PageControl extends Component<IProps, IStates> {
 
   static getDerivedStateFromProps(props: IProps, state: IStates): IStates {
     return {
-      currentPageIdx: Math.min(
-        state.currentPageIdx,
-        props.totalPages - 1
-      )
+      currentPageIdx: Math.min(state.currentPageIdx, props.totalPages - 1)
     };
   }
 


### PR DESCRIPTION
Fixes #658.

## Current Behavior ( Optional for new feature )
### Description
If page is changed to a page whose number is greater than total amount of pages (can happen when number of pages changes in between page changes), then the current page will still be set to that page instead of falling back to the new last page.

### Screenshots
See #658

## New Behavior
### Description
Now when the total number of pages changes after a page change, the page selected will fall back to the last page.

### Screenshots
![result](https://user-images.githubusercontent.com/3276350/81352714-2f851880-9095-11ea-9fd2-54af376829d2.gif)

## Note
This solution uses `getDerivedStateFromProps`, which is [not a recommended approach to handling derived state](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html). An alternative solution would be letting the parent of `PageControl` component control the current index, but I think this will introduce unneeded complexity. Additionally, the logic within the `getDerivedStateFromProps` method will not override any local changes to the `currentPageIdx` value if it's less than or equal to the total number of pages, which is expected behaviour.
