### PR TITLE
Add tabs component

### DIFF
--- a/frontend/src/component/ui/Tabs.spec.tsx
+++ b/frontend/src/component/ui/Tabs.spec.tsx
@@ -7,12 +7,12 @@ describe('Tabs component', () => {
     render(<Tabs />);
   });
 
-  test('should not render anything when there are no tabs', () => {
+  test('should not render anything when there is no tab', () => {
     const { container } = render(<Tabs />);
     expect(container.innerHTML).toBeFalsy();
   });
 
-  test('should render first tab content by default', () => {
+  test('should render first tab by default', () => {
     const tabs = ['Content 1', 'Content 2', 'Content 3'];
 
     const { container } = render(<Tabs>{tabs}</Tabs>);
@@ -38,13 +38,12 @@ describe('Tabs component', () => {
 
     const { container } = render(<Tabs ref={tabRef}>{tabs}</Tabs>);
 
-    for (let tabIdx = 0; tabIdx < tabs.length; tabIdx++) {
-      tabRef.current!.showTab(tabIdx);
-      expect(container.textContent).toContain(tabs[tabIdx]);
-    }
+    expect(container.textContent).not.toContain(tabs[1]);
+    tabRef.current!.showTab(1);
+    expect(container.textContent).toContain(tabs[1]);
   });
 
-  test('should not render anything when negative index is given', () => {
+  test('should render nothing when negative index is given', () => {
     const tabs = ['Content 1', 'Content 2', 'Content 3'];
     const tabRef = React.createRef<Tabs>();
 

--- a/frontend/src/component/ui/Tabs.spec.tsx
+++ b/frontend/src/component/ui/Tabs.spec.tsx
@@ -43,4 +43,24 @@ describe('Tabs component', () => {
       expect(container.textContent).toContain(tabs[tabIdx]);
     }
   });
+
+  test('should not render anything when negative index is given', () => {
+    const tabs = ['Content 1', 'Content 2', 'Content 3'];
+    const tabRef = React.createRef<Tabs>();
+
+    const { container } = render(<Tabs ref={tabRef}>{tabs}</Tabs>);
+
+    tabRef.current!.showTab(-1);
+    expect(container.innerHTML).toBeFalsy();
+  });
+
+  test('should not render anything when index grater than tabs count is given', () => {
+    const tabs = ['Content 1', 'Content 2', 'Content 3'];
+    const tabRef = React.createRef<Tabs>();
+
+    const { container } = render(<Tabs ref={tabRef}>{tabs}</Tabs>);
+
+    tabRef.current!.showTab(tabs.length + 1);
+    expect(container.innerHTML).toBeFalsy();
+  });
 });

--- a/frontend/src/component/ui/Tabs.spec.tsx
+++ b/frontend/src/component/ui/Tabs.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Tabs } from './Tabs';
+
+describe('Tabs component', () => {
+  test('should render without crash', () => {
+    render(<Tabs />);
+  });
+
+  test('should not render anything when there are no tabs', () => {
+    const { container } = render(<Tabs />);
+    expect(container.innerHTML).toBeFalsy();
+  });
+
+  test('should render first tab content by default', () => {
+    const tabs = ['Content 1', 'Content 2', 'Content 3'];
+
+    const { container } = render(<Tabs>{tabs}</Tabs>);
+
+    expect(container.textContent).toContain(tabs[0]);
+    expect(container.textContent).not.toContain(tabs[1]);
+    expect(container.textContent).not.toContain(tabs[2]);
+  });
+
+  test('should render correct tab when default index is given', () => {
+    const tabs = ['Content 1', 'Content 2', 'Content 3'];
+
+    const { container } = render(<Tabs defaultTabIdx={1}>{tabs}</Tabs>);
+
+    expect(container.textContent).not.toContain(tabs[0]);
+    expect(container.textContent).toContain(tabs[1]);
+    expect(container.textContent).not.toContain(tabs[2]);
+  });
+
+  test('should render correct tab content when showTab is invoked', () => {
+    const tabs = ['Content 1', 'Content 2', 'Content 3'];
+    const tabRef = React.createRef<Tabs>();
+
+    const { container } = render(<Tabs ref={tabRef}>{tabs}</Tabs>);
+
+    for (let tabIdx = 0; tabIdx < tabs.length; tabIdx++) {
+      tabRef.current!.showTab(tabIdx);
+      expect(container.textContent).toContain(tabs[tabIdx]);
+    }
+  });
+});

--- a/frontend/src/component/ui/Tabs.tsx
+++ b/frontend/src/component/ui/Tabs.tsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+
+interface IProps {
+  defaultTabIdx: number;
+}
+
+interface IState {
+  tabIdx: number;
+}
+
+const DEFAULT_PROP: Partial<IProps> = {
+  defaultTabIdx: 0
+};
+
+export class Tabs extends Component<IProps, IState> {
+  public static defaultProps = DEFAULT_PROP;
+
+  constructor(props: IProps) {
+    super(props);
+    this.state = { tabIdx: props.defaultTabIdx };
+  }
+
+  showTab(tabIdx: number) {
+    this.setState({ tabIdx: tabIdx });
+  }
+
+  render = () => {
+    if (!this.props.children) {
+      return false;
+    }
+    const children = React.Children.toArray(this.props.children);
+    const { tabIdx } = this.state;
+    if (tabIdx < 0) {
+      return false;
+    }
+    if (tabIdx >= children.length) {
+      return false;
+    }
+
+    return children[tabIdx];
+  };
+}

--- a/frontend/src/component/ui/Tabs.tsx
+++ b/frontend/src/component/ui/Tabs.tsx
@@ -28,8 +28,10 @@ export class Tabs extends Component<IProps, IState> {
     if (!this.props.children) {
       return false;
     }
+
     const children = React.Children.toArray(this.props.children);
     const { tabIdx } = this.state;
+
     if (tabIdx < 0) {
       return false;
     }


### PR DESCRIPTION
Part of #612 

## New Behavior
### Description
Add Tabs component which can be handy when there a set of pages of which one should be shown at a time and rendering should be controlled with the index of the pages.
### Screenshots
![image](https://user-images.githubusercontent.com/18581705/81412477-8c4e0500-9161-11ea-9809-e50b1a11bead.png)
