### PR TITLE
Refactor Navigation Menu Items spacing

### DIFF
--- a/frontend/src/component/ui/Navigation.scss
+++ b/frontend/src/component/ui/Navigation.scss
@@ -11,7 +11,7 @@
       font-weight: $font-weight-semi-bold;
       word-break: break-word;
       padding: 10px 15px;
-      margin: 10px;
+      margin: 5px 10px;
       cursor: pointer;
       @include round-corner;
 

--- a/frontend/src/component/ui/Navigation.scss
+++ b/frontend/src/component/ui/Navigation.scss
@@ -1,4 +1,5 @@
 @import '../styles/color';
+@import '../styles/corner';
 @import '../styles/font';
 
 .navigation {
@@ -9,8 +10,10 @@
     > li {
       font-weight: $font-weight-semi-bold;
       word-break: break-word;
-      padding: 15px 20px;
+      padding: 10px 15px;
+      margin: 10px;
       cursor: pointer;
+      @include round-corner;
 
       &.active {
         background-color: color-transparent-black(0.06);


### PR DESCRIPTION
Part of #612 

## Current Behavior ( Optional for new feature )
### Description
The menu didn't have any spacing between the items and the border of the component.
### Screenshots
![image](https://user-images.githubusercontent.com/18581705/81436625-6a677900-9187-11ea-9d75-9c8dea090132.png)


## New Behavior
### Description
Added padding and margins to make spaces between the menu items and the parent component.
### Screenshots
![image](https://user-images.githubusercontent.com/18581705/81436545-4dcb4100-9187-11ea-87de-7affa03ca58c.png)
