### PR TITLE
Clean up Google & Facebook identify providers

### DIFF
--- a/backend/app/adapter/facebook/identityprovider.go
+++ b/backend/app/adapter/facebook/identityprovider.go
@@ -67,7 +67,7 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessTo
 		return "", err
 	}
 
-	query := u.Query()
+	query := url.Values{}
 	query.Set("client_id", clientID)
 	query.Set("redirect_uri", redirectURI)
 	query.Set("client_secret", clientSecret)

--- a/backend/app/adapter/facebook/identityprovider.go
+++ b/backend/app/adapter/facebook/identityprovider.go
@@ -74,18 +74,8 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessTo
 	query.Set("code", authorizationCode)
 	u.RawQuery = query.Encode()
 
-	body := url.Values{}
-	body.Set("client_id", clientID)
-	body.Set("redirect_uri", redirectURI)
-	body.Set("client_secret", clientSecret)
-	body.Set("code", authorizationCode)
-
-	headers := map[string]string{
-		"Content-Type": "application/x-www-form-urlencoded",
-	}
-
 	apiRes := fbAccessTokenResponse{}
-	err = g.httpRequest.JSON(http.MethodPost, u.String(), headers, body.Encode(), &apiRes)
+	err = g.httpRequest.JSON(http.MethodPost, u.String(), map[string]string{}, "", &apiRes)
 
 	if err != nil {
 		return "", err

--- a/backend/app/adapter/facebook/identityprovider_integration_test.go
+++ b/backend/app/adapter/facebook/identityprovider_integration_test.go
@@ -136,7 +136,6 @@ func TestIdentityProvider_RequestAccessToken(t *testing.T) {
 					assert.Equal(t, testCase.redirectURI, req.URL.Query().Get("redirect_uri"))
 					assert.Equal(t, "POST", req.Method)
 					assert.Equal(t, "application/json", req.Header.Get("Accept"))
-					assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
 
 					return testCase.httpResponse, testCase.httpErr
 				})

--- a/backend/app/adapter/github/identityprovider.go
+++ b/backend/app/adapter/github/identityprovider.go
@@ -46,14 +46,18 @@ func (g IdentityProvider) GetAuthorizationURL() string {
 func (g IdentityProvider) RequestAccessToken(authorizationCode string) (accessToken string, err error) {
 	clientID := g.clientID
 	clientSecret := g.clientSecret
-	body := fmt.Sprintf("client_id=%s&client_secret=%s&code=%s", clientID, clientSecret, authorizationCode)
+
+	body := url.Values{}
+	body.Set("client_id", clientID)
+	body.Set("client_secret", clientSecret)
+	body.Set("code", authorizationCode)
 
 	headers := map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
 	apiRes := accessTokenResponse{}
-	err = g.http.JSON(http.MethodPost, accessTokenAPI, headers, body, &apiRes)
+	err = g.http.JSON(http.MethodPost, accessTokenAPI, headers, body.Encode(), &apiRes)
 	if err != nil {
 		return "", err
 	}

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -75,19 +75,12 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	query.Set("grant_type", grantType)
 	u.RawQuery = query.Encode()
 
-	body := url.Values{}
-	body.Set("code", authorizationCode)
-	body.Set("client_id", clientID)
-	body.Set("client_secret", clientSecret)
-	body.Set("redirect_uri", redirectURI)
-	body.Set("grant_type", grantType)
-
 	headers := map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
 
 	apiRes := accessTokenResponse{}
-	err = g.httpRequest.JSON(http.MethodPost, u.String(), headers, body.Encode(), &apiRes)
+	err = g.httpRequest.JSON(http.MethodPost, u.String(), headers, "", &apiRes)
 	if err != nil {
 		return "", err
 	}

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -75,12 +75,8 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 	query.Set("grant_type", grantType)
 	u.RawQuery = query.Encode()
 
-	headers := map[string]string{
-		"Content-Type": "application/x-www-form-urlencoded",
-	}
-
 	apiRes := accessTokenResponse{}
-	err = g.httpRequest.JSON(http.MethodPost, u.String(), headers, "", &apiRes)
+	err = g.httpRequest.JSON(http.MethodPost, u.String(), map[string]string{}, "", &apiRes)
 	if err != nil {
 		return "", err
 	}

--- a/backend/app/adapter/google/identityprovider.go
+++ b/backend/app/adapter/google/identityprovider.go
@@ -67,7 +67,7 @@ func (g IdentityProvider) RequestAccessToken(authorizationCode string) (string, 
 		return "", err
 	}
 
-	query := u.Query()
+	query := url.Values{}
 	query.Set("code", authorizationCode)
 	query.Set("client_id", clientID)
 	query.Set("client_secret", clientSecret)

--- a/backend/app/adapter/google/identityprovider_integration_test.go
+++ b/backend/app/adapter/google/identityprovider_integration_test.go
@@ -132,7 +132,6 @@ func TestIdentityProvider_RequestAccessToken(t *testing.T) {
 					assert.Equal(t, "authorization_code", req.URL.Query().Get("grant_type"))
 					assert.Equal(t, "POST", req.Method)
 					assert.Equal(t, "application/json", req.Header.Get("Accept"))
-					assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
 
 					return testCase.httpResponse, testCase.httpErr
 				})


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Redundant request body is added even though the data is already included in query parameters.

## New Behavior
### Description
Remove unnecessary request body.
