### PR TITLE
Auto generate ID for existing accounts during account linking

### DIFF
--- a/backend/app/adapter/sqldb/user.go
+++ b/backend/app/adapter/sqldb/user.go
@@ -173,6 +173,28 @@ VALUES ($1, $2, $3, $4, $5, $6)
 	return err
 }
 
+// UpdateUserID updates the ID of an user in user table with given email address.
+func (u UserSQL) UpdateUserID(email string, userID string) error {
+	isExist, err := u.IsEmailExist(email)
+	if err != nil {
+		return err
+	}
+
+	if !isExist {
+		return repository.ErrEntryNotFound(fmt.Sprintf("email %s does not exist", email))
+	}
+	statement := fmt.Sprintf(`
+UPDATE "%s"
+SET "%s"=$1
+WHERE "%s"=$2
+`,
+		table.User.TableName,
+		table.User.ColumnID,
+		table.User.ColumnEmail)
+	_, err = u.db.Exec(statement, userID, email)
+	return err
+}
+
 // NewUserSQL creates UserSQL
 func NewUserSQL(db *sql.DB) *UserSQL {
 	return &UserSQL{

--- a/backend/app/adapter/sqldb/user_integration_test.go
+++ b/backend/app/adapter/sqldb/user_integration_test.go
@@ -341,6 +341,56 @@ func TestUserSql_CreateUser(t *testing.T) {
 	}
 }
 
+func TestUserSQL_UpdateUserID(t *testing.T) {
+	testCases := []struct {
+		name      string
+		email     string
+		tableRows []userTableRow
+		hasErr    bool
+	}{
+		{
+			name:      "user not found",
+			email:     "alpha@example.com",
+			tableRows: []userTableRow{},
+			hasErr:    true,
+		},
+		{
+			name:  "update user ID successfully",
+			email: "alpha@example.com",
+			tableRows: []userTableRow{
+				{email: "alpha@example.com"},
+			},
+			hasErr: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dbtest.AccessTestDB(
+				dbConnector,
+				dbMigrationTool,
+				dbMigrationRoot,
+				dbConfig,
+				func(sqlDB *sql.DB) {
+					insertUserTableRows(t, sqlDB, testCase.tableRows)
+
+					userRepo := sqldb.NewUserSQL(sqlDB)
+
+					err := userRepo.UpdateUserID(testCase.email, "alpha")
+					if testCase.hasErr {
+						assert.NotEqual(t, nil, err)
+						return
+					}
+					assert.Equal(t, nil, err)
+
+					user, err := userRepo.GetUserByEmail(testCase.email)
+					assert.Equal(t, nil, err)
+					assert.Equal(t, "alpha", user.ID)
+				})
+		})
+	}
+}
+
 func insertUserTableRows(t *testing.T, sqlDB *sql.DB, tableRows []userTableRow) {
 	for _, tableRow := range tableRows {
 		_, err := sqlDB.Exec(

--- a/backend/app/usecase/repository/user.go
+++ b/backend/app/usecase/repository/user.go
@@ -9,4 +9,5 @@ type User interface {
 	GetUserByID(id string) (entity.User, error)
 	GetUserByEmail(email string) (entity.User, error)
 	CreateUser(user entity.User) error
+	UpdateUserID(email string, userID string) error
 }

--- a/backend/app/usecase/repository/user_fake.go
+++ b/backend/app/usecase/repository/user_fake.go
@@ -74,6 +74,17 @@ func (u *UserFake) CreateUser(user entity.User) error {
 	return nil
 }
 
+// UpdateUserID updates the ID of a user in the repository given email.
+func (u *UserFake) UpdateUserID(email string, userID string) error {
+	for idx, user := range u.users {
+		if user.Email == email {
+			u.users[idx].ID = userID
+			return nil
+		}
+	}
+	return ErrEntryNotFound("email does not exist")
+}
+
 // NewUserFake create in memory user repository implementation.
 func NewUserFake(users []entity.User) UserFake {
 	return UserFake{

--- a/backend/app/usecase/sso/linker.go
+++ b/backend/app/usecase/sso/linker.go
@@ -44,7 +44,7 @@ func (a AccountLinker) CreateAndLinkAccount(ssoUser entity.SSOUser) error {
 
 	user, err := a.userRepo.GetUserByEmail(ssoUser.Email)
 	if err == nil {
-		return a.ssoMap.CreateMapping(ssoUser.ID, user.ID)
+		return a.linkExistingAccount(ssoUser, user)
 	}
 
 	var errNotFound repository.ErrEntryNotFound
@@ -57,6 +57,23 @@ func (a AccountLinker) CreateAndLinkAccount(ssoUser entity.SSOUser) error {
 		return err
 	}
 	return a.ssoMap.CreateMapping(ssoUser.ID, userID)
+}
+
+func (a AccountLinker) linkExistingAccount(ssoUser entity.SSOUser, user entity.User) error {
+	if len(user.ID) > 0 {
+		return a.ssoMap.CreateMapping(ssoUser.ID, user.ID)
+	}
+
+	newID, err := a.generateUnassignedUserID()
+	if err != nil {
+		return err
+	}
+
+	err = a.userRepo.UpdateUserID(ssoUser.Email, newID)
+	if err != nil {
+		return err
+	}
+	return a.ssoMap.CreateMapping(ssoUser.ID, newID)
 }
 
 func (a AccountLinker) createAccount(ssoUser entity.SSOUser) (string, error) {

--- a/backend/app/usecase/sso/linker_test.go
+++ b/backend/app/usecase/sso/linker_test.go
@@ -86,12 +86,31 @@ func TestLinker_CreateAndLinkAccount(t *testing.T) {
 	}{
 		{
 			name:              "account exists not linked",
-			key:               "alpha",
 			mappingUserIDs:    []string{},
 			mappingSSOUserIDs: []string{},
 			users: []entity.User{
 				{
 					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+			},
+			ssoUser: entity.SSOUser{
+				ID:    "gama",
+				Email: "alpha@example.com",
+			},
+			user: entity.User{
+				ID:    "alpha",
+				Email: "alpha@example.com",
+			},
+			expectedIDExist: false,
+		},
+		{
+			name:              "account exists with empty ID",
+			key:               "alpha",
+			mappingUserIDs:    []string{},
+			mappingSSOUserIDs: []string{},
+			users: []entity.User{
+				{
 					Email: "alpha@example.com",
 				},
 			},


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Existing accounts have no user ID. This results in external account being mapped to empty ID during linking and hence repeated sign in.

## New Behavior
### Description
Auto generate ID for existing accounts with empty ID during account linking.