### PR TITLE
Extract preference toggles into a separate subsection

### DIFF
--- a/backend/app/usecase/feature/static.go
+++ b/backend/app/usecase/feature/static.go
@@ -38,6 +38,7 @@ func (s StaticDecisionMakerFactory) NewDecision(
 			"google-sign-in":           true,
 			"search-bar":               true,
 			"user-short-links-section": true,
+			"preference-toggles":       true,
 		},
 	}
 }

--- a/frontend/src/component/UIFactory.tsx
+++ b/frontend/src/component/UIFactory.tsx
@@ -23,6 +23,7 @@ import { PublicListingToggle } from './pages/shared/PublicListingToggle';
 import { ShortLinkService } from '../service/ShortLink.service';
 import { UserShortLinksSection } from './pages/shared/UserShortLinksSection';
 import { AnalyticsService } from '../service/Analytics.service';
+import { PreferenceTogglesSubSection } from './pages/shared/PreferenceTogglesSubSection';
 
 export class UIFactory {
   private ToggledGoogleSignInButton: ComponentType<any>;
@@ -30,6 +31,7 @@ export class UIFactory {
   private ToggledFacebookSignInButton: ComponentType<any>;
   private ToggledSearchBar: ComponentType<any>;
   private ToggledViewChangeLogButton: ComponentType<any>;
+  private ToggledPreferenceTogglesSubSection: ComponentType<any>;
   private ToggledPublicListingToggle: ComponentType<any>;
   private ToggledUserShortLinksSection: ComponentType<any>;
 
@@ -73,6 +75,12 @@ export class UIFactory {
     this.ToggledViewChangeLogButton = withFeatureToggle(
       ViewChangeLogButton,
       includeViewChangeLogButton
+    );
+
+    const includePreferenceTogglesSubSection = this.featureDecisionService.includePreferenceTogglesSubSection();
+    this.ToggledPreferenceTogglesSubSection = withFeatureToggle(
+      PreferenceTogglesSubSection,
+      includePreferenceTogglesSubSection
     );
 
     const includePublicListingToggle = this.featureDecisionService.includePublicListingToggle();
@@ -139,6 +147,10 @@ export class UIFactory {
         facebookSignInLink={this.authService.facebookSignInLink()}
       />
     );
+  }
+
+  public createPreferenceTogglesSubSection(props: any): ReactElement {
+    return <this.ToggledPreferenceTogglesSubSection {...props} />;
   }
 
   public createPublicListingToggle(props: any): ReactElement {

--- a/frontend/src/component/pages/shared/CreateShortLinkSection.scss
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.scss
@@ -13,7 +13,3 @@
   line-height: 20px;
   margin: 10px;
 }
-
-.preference-toggles {
-  border-top: 2px solid $color-divider;
-}

--- a/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
@@ -63,12 +63,11 @@ export class CreateShortLinkSection extends Component<Props> {
           </div>
         </div>
         <div className={'input-error'}>{this.props.inputErr}</div>
-        <div className={'preference-toggles'}>
-          {this.props.uiFactory.createPublicListingToggle({
-            defaultIsEnabled: this.props.isShortLinkPublic,
-            onToggleClick: this.props.onPublicToggleClick
-          })}
-        </div>
+        {this.props.uiFactory.createPreferenceTogglesSubSection({
+          uiFactory: this.props.uiFactory,
+          isShortLinkPublic: this.props.isShortLinkPublic,
+          onPublicToggleClick: this.props.onPublicToggleClick
+        })}
         {this.props.createdUrl && (
           <div className={'short-link-usage-wrapper'}>
             <ShortLinkUsage

--- a/frontend/src/component/pages/shared/PreferenceTogglesSubSection.scss
+++ b/frontend/src/component/pages/shared/PreferenceTogglesSubSection.scss
@@ -1,0 +1,5 @@
+@import '../../styles/color';
+
+.preference-toggles {
+  border-top: 2px solid $color-divider;
+}

--- a/frontend/src/component/pages/shared/PreferenceTogglesSubSection.tsx
+++ b/frontend/src/component/pages/shared/PreferenceTogglesSubSection.tsx
@@ -1,0 +1,23 @@
+import React, { Component, ReactElement } from 'react';
+import { UIFactory } from '../../UIFactory';
+
+import './PreferenceTogglesSubSection.scss';
+
+interface Props {
+  uiFactory: UIFactory;
+  isShortLinkPublic?: boolean;
+  onPublicToggleClick?: (enabled: boolean) => void;
+}
+
+export class PreferenceTogglesSubSection extends Component<Props> {
+  render(): ReactElement {
+    return (
+      <div className={'preference-toggles'}>
+        {this.props.uiFactory.createPublicListingToggle({
+          defaultIsEnabled: this.props.isShortLinkPublic,
+          onToggleClick: this.props.onPublicToggleClick
+        })}
+      </div>
+    );
+  }
+}

--- a/frontend/src/service/feature-decision/DynamicDecision.service.ts
+++ b/frontend/src/service/feature-decision/DynamicDecision.service.ts
@@ -24,6 +24,10 @@ export class DynamicDecisionService implements IFeatureDecisionService {
     return this.makeDecision('change-log');
   }
 
+  includePreferenceTogglesSubSection(): Promise<boolean> {
+    return this.makeDecision('preference-toggles');
+  }
+
   includePublicListingToggle(): Promise<boolean> {
     return this.makeDecision('public-listing');
   }

--- a/frontend/src/service/feature-decision/FeatureDecision.service.ts
+++ b/frontend/src/service/feature-decision/FeatureDecision.service.ts
@@ -4,6 +4,7 @@ export interface IFeatureDecisionService {
   includeGithubSignInButton(): Promise<boolean>;
   includeGoogleSignInButton(): Promise<boolean>;
   includeFacebookSignInButton(): Promise<boolean>;
+  includePreferenceTogglesSubSection(): Promise<boolean>;
   includePublicListingToggle(): Promise<boolean>;
   includeUserShortLinksSection(): Promise<boolean>;
 }


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Divider for preference toggles show up even when there is no toggle.

## New Behavior
### Description
Extract preference toggles into a separate subsection section so that we can dynamically hide it when there is no toggle enabled.
