### PR TITLE
Use UTC time when creating new Change

### DIFF
--- a/backend/app/usecase/changelog/changelog.go
+++ b/backend/app/usecase/changelog/changelog.go
@@ -29,7 +29,7 @@ type Persist struct {
 
 // CreateChange creates a new change in the data store.
 func (p Persist) CreateChange(title string, summaryMarkdown *string) (entity.Change, error) {
-	now := p.timer.Now()
+	now := p.timer.Now().UTC()
 	key, err := p.keyGen.NewKey()
 	if err != nil {
 		return entity.Change{}, err

--- a/backend/app/usecase/changelog/changelog_test.go
+++ b/backend/app/usecase/changelog/changelog_test.go
@@ -16,7 +16,7 @@ import (
 func TestPersist_CreateChange(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	summaryMarkdown1 := "summary 1"
 	summaryMarkdown2 := "summary 2"
 	summaryMarkdown3 := "summary 3"


### PR DESCRIPTION
Server time may not be in UTC and therefore when new change is created released_at may not be in UTC as well. In order to maintain same time irrespective of server location we should use enforce UTC time