### PR TITLE
Remove canonical meta tag from index.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -35,7 +35,6 @@
           content="Short enables people to type less for their favorite web sites"/>
     <meta property="og:image"
           content="https://short-d.com/promo/small-tile.png"/>
-    <meta property="og:url" content="https://short-d.com"/>
     <meta property="og:type" content="website"/>
 
     <!-- Twitter -->

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -27,7 +27,6 @@
     <meta name="description"
           content="Short enables people to type less for their favorite web sites">
     <meta name="robots" content="index, follow">
-    <link href="https://short-d.com" rel="canonical">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Short: Free link shortening service"/>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -34,6 +34,7 @@
           content="Short enables people to type less for their favorite web sites"/>
     <meta property="og:image"
           content="https://short-d.com/promo/small-tile.png"/>
+    <meta property="og:url" content="https://short-d.com"/>
     <meta property="og:type" content="website"/>
 
     <!-- Twitter -->


### PR DESCRIPTION
Canonical meta tag prevents use of custom og:tags for social media sharing on LinkedIn/Facebook/Twitter.

![Screenshot from 2020-05-20 21-38-56](https://user-images.githubusercontent.com/20877996/82470133-91f10680-9ae2-11ea-8dc0-5c662032e958.png)

