### PR TITLE
Add Auth HOC to wrap authorized pages

### DIFF
--- a/frontend/src/component/hoc/withPageAuth.tsx
+++ b/frontend/src/component/hoc/withPageAuth.tsx
@@ -33,11 +33,7 @@ export default function(
         if (!this.isComponentMounted) {
           return;
         }
-        this.setState({
-          decision: decision
-            ? AuthDecision.AUTHORIZED
-            : AuthDecision.UNAUTHORIZED
-        });
+        this.setState({ decision: this.toAuthDecision(decision) });
       });
     }
 
@@ -57,6 +53,13 @@ export default function(
 
       // TODO(issue#816): add loading page component
       return <div />;
+    }
+
+    private toAuthDecision(featureDecision: boolean): AuthDecision {
+      if (!featureDecision) {
+        return AuthDecision.UNAUTHORIZED;
+      }
+      return AuthDecision.AUTHORIZED;
     }
   };
 }

--- a/frontend/src/component/hoc/withPageAuth.tsx
+++ b/frontend/src/component/hoc/withPageAuth.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { NotFoundPage } from '../pages/NotFoundPage';
+
+export default function(
+  WrappedComponent: React.ComponentType<any>,
+  makeAuthDecision: Promise<boolean>
+) {
+  enum AuthDecision {
+    AUTHORIZED,
+    UNAUTHORIZED,
+    PENDING
+  }
+
+  interface IState {
+    decision: AuthDecision;
+  }
+
+  return class extends React.Component<any, IState> {
+    private isComponentMounted: boolean;
+
+    constructor(props: any) {
+      super(props);
+      this.state = {
+        decision: AuthDecision.PENDING
+      };
+      this.isComponentMounted = false;
+    }
+
+    componentDidMount(): void {
+      this.isComponentMounted = true;
+
+      makeAuthDecision.then(decision => {
+        if (!this.isComponentMounted) {
+          return;
+        }
+        this.setState({
+          decision: decision
+            ? AuthDecision.AUTHORIZED
+            : AuthDecision.UNAUTHORIZED
+        });
+      });
+    }
+
+    componentWillUnmount(): void {
+      this.isComponentMounted = false;
+    }
+
+    render() {
+      const { decision } = this.state;
+      if (decision === AuthDecision.AUTHORIZED) {
+        return <WrappedComponent {...this.props} />;
+      }
+
+      if (decision === AuthDecision.UNAUTHORIZED) {
+        return <NotFoundPage />;
+      }
+
+      // TODO(issue#816): add loading page component
+      return <div />;
+    }
+  };
+}


### PR DESCRIPTION
Part of #612 

## New Behavior
### Description
Add `withPageAuth` HOC to wrap auth protected pages. It currently returns a 404 page when the user isn't authorized to view the page and displays the wrapped page if authorized.