### PR TITLE
Make feature toggle decision at mount time instead of build time

### DIFF
--- a/frontend/src/component/UIFactory.tsx
+++ b/frontend/src/component/UIFactory.tsx
@@ -55,52 +55,52 @@ export class UIFactory {
     private shortLinkService: ShortLinkService,
     private analyticsService: AnalyticsService
   ) {
-    const includeGoogleSignInButton = this.featureDecisionService.includeGoogleSignInButton();
+    const includeGoogleSignInButton = this.featureDecisionService.includeGoogleSignInButton;
     this.ToggledGoogleSignInButton = withFeatureToggle(
       GoogleSignInButton,
       includeGoogleSignInButton
     );
 
-    const includeGithubSignInButton = this.featureDecisionService.includeGithubSignInButton();
+    const includeGithubSignInButton = this.featureDecisionService.includeGithubSignInButton;
     this.ToggledGithubSignInButton = withFeatureToggle(
       GithubSignInButton,
       includeGithubSignInButton
     );
 
-    const includeFacebookSignInButton = this.featureDecisionService.includeFacebookSignInButton();
+    const includeFacebookSignInButton = this.featureDecisionService.includeFacebookSignInButton;
     this.ToggledFacebookSignInButton = withFeatureToggle(
       FacebookSignInButton,
       includeFacebookSignInButton
     );
 
-    const includeSearchBar = this.featureDecisionService.includeSearchBar();
+    const includeSearchBar = this.featureDecisionService.includeSearchBar;
     this.ToggledSearchBar = withFeatureToggle(SearchBar, includeSearchBar);
 
-    const includeViewChangeLogButton = this.featureDecisionService.includeViewChangeLogButton();
+    const includeViewChangeLogButton = this.featureDecisionService.includeViewChangeLogButton;
     this.ToggledViewChangeLogButton = withFeatureToggle(
       ViewChangeLogButton,
       includeViewChangeLogButton
     );
 
-    const includePreferenceTogglesSubSection = this.featureDecisionService.includePreferenceTogglesSubSection();
+    const includePreferenceTogglesSubSection = this.featureDecisionService.includePreferenceTogglesSubSection;
     this.ToggledPreferenceTogglesSubSection = withFeatureToggle(
       PreferenceTogglesSubSection,
       includePreferenceTogglesSubSection
     );
 
-    const includePublicListingToggle = this.featureDecisionService.includePublicListingToggle();
+    const includePublicListingToggle = this.featureDecisionService.includePublicListingToggle;
     this.ToggledPublicListingToggle = withFeatureToggle(
       PublicListingToggle,
       includePublicListingToggle
     );
 
-    const includeUserShortLinksSection = this.featureDecisionService.includeUserShortLinksSection();
+    const includeUserShortLinksSection = this.featureDecisionService.includeUserShortLinksSection;
     this.ToggledUserShortLinksSection = withFeatureToggle(
       UserShortLinksSection,
       includeUserShortLinksSection
     );
 
-    const includeAdminPage = this.featureDecisionService.includeAdminPage();
+    const includeAdminPage = this.featureDecisionService.includeAdminPage;
     this.AuthedAdminPage = withPageAuth(AdminPage, includeAdminPage);
   }
 

--- a/frontend/src/component/hoc/withFeatureToggle.tsx
+++ b/frontend/src/component/hoc/withFeatureToggle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function(
   WrappedComponent: React.ComponentType<any>,
-  featureDecision: Promise<boolean>
+  featureDecision: () => Promise<boolean>
 ): React.ComponentType<any> {
   interface IState {
     isFeatureEnabled: boolean;
@@ -22,7 +22,7 @@ export default function(
     componentDidMount(): void {
       this.isComponentMounted = true;
 
-      featureDecision.then(decision => {
+      featureDecision().then(decision => {
         if (!this.isComponentMounted) {
           return;
         }

--- a/frontend/src/component/hoc/withFeatureToggle.tsx
+++ b/frontend/src/component/hoc/withFeatureToggle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function(
   WrappedComponent: React.ComponentType<any>,
-  featureDecision: () => Promise<boolean>
+  makeFeatureDecision: () => Promise<boolean>
 ): React.ComponentType<any> {
   interface IState {
     isFeatureEnabled: boolean;
@@ -22,7 +22,7 @@ export default function(
     componentDidMount(): void {
       this.isComponentMounted = true;
 
-      featureDecision().then(decision => {
+      makeFeatureDecision().then(decision => {
         if (!this.isComponentMounted) {
           return;
         }

--- a/frontend/src/component/hoc/withPageAuth.tsx
+++ b/frontend/src/component/hoc/withPageAuth.tsx
@@ -3,7 +3,7 @@ import { NotFoundPage } from '../pages/NotFoundPage';
 
 export default function(
   WrappedComponent: React.ComponentType<any>,
-  makeAuthDecision: Promise<boolean>
+  makeAuthDecision: () => Promise<boolean>
 ) {
   enum AuthDecision {
     AUTHORIZED,
@@ -29,7 +29,7 @@ export default function(
     componentDidMount(): void {
       this.isComponentMounted = true;
 
-      makeAuthDecision.then(decision => {
+      makeAuthDecision().then(decision => {
         if (!this.isComponentMounted) {
           return;
         }

--- a/frontend/src/service/feature-decision/DynamicDecision.service.ts
+++ b/frontend/src/service/feature-decision/DynamicDecision.service.ts
@@ -4,41 +4,41 @@ import { ShortHTTPApi } from '../ShortHTTP.api';
 export class DynamicDecisionService implements IFeatureDecisionService {
   constructor(private shortHTTPApi: ShortHTTPApi) {}
 
-  includeFacebookSignInButton(): Promise<boolean> {
+  includeFacebookSignInButton = (): Promise<boolean> => {
     return this.makeDecision('facebook-sign-in');
-  }
+  };
 
-  includeGithubSignInButton(): Promise<boolean> {
+  includeGithubSignInButton = (): Promise<boolean> => {
     return this.makeDecision('github-sign-in');
-  }
+  };
 
-  includeGoogleSignInButton(): Promise<boolean> {
+  includeGoogleSignInButton = (): Promise<boolean> => {
     return this.makeDecision('google-sign-in');
-  }
+  };
 
-  includeSearchBar(): Promise<boolean> {
+  includeSearchBar = (): Promise<boolean> => {
     return this.makeDecision('search-bar');
-  }
+  };
 
-  includeViewChangeLogButton(): Promise<boolean> {
+  includeViewChangeLogButton = (): Promise<boolean> => {
     return this.makeDecision('change-log');
-  }
+  };
 
-  includePreferenceTogglesSubSection(): Promise<boolean> {
+  includePreferenceTogglesSubSection = (): Promise<boolean> => {
     return this.makeDecision('preference-toggles');
-  }
+  };
 
-  includePublicListingToggle(): Promise<boolean> {
+  includePublicListingToggle = (): Promise<boolean> => {
     return this.makeDecision('public-listing');
-  }
+  };
 
-  includeUserShortLinksSection(): Promise<boolean> {
+  includeUserShortLinksSection = (): Promise<boolean> => {
     return this.makeDecision('user-short-links-section');
-  }
+  };
 
-  includeAdminPage(): Promise<boolean> {
+  includeAdminPage = (): Promise<boolean> => {
     return this.makeDecision('admin-panel');
-  }
+  };
 
   private makeDecision(featureID: string): Promise<boolean> {
     return this.shortHTTPApi.getFeatureToggle(featureID);


### PR DESCRIPTION
Part of #612 

## Current Behavior ( Optional for new feature )
### Description
The feature toggle and auth toggle decision is currently being made in constructor of UIFactory making it happen only once during the initial setup unless the page is reloaded. With the current dynamic(auth based) feature toggle functionality in place, this won't work as users will keep alternating between logged in and out state. That is, when a user is initially logged out, the permission based features will be unavailable and it will continue to be unavailable even after logging in.

## New Behavior
### Description
Instead of passing the decision(`Promise<bool>`) in the `withFeatureToggle` and `withPageAuth` HOCs, we pass the decision maker so that it can be called while mounting the component and thus satisfying the dynamicity.