### PR TITLE
Search resources concurrently

### DIFF
--- a/backend/app/usecase/search/order/order.go
+++ b/backend/app/usecase/search/order/order.go
@@ -14,3 +14,11 @@ type Order interface {
 	ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.ShortLink
 	ArrangeUsers(users []entity.User) []entity.User
 }
+
+// NewOrder creates Order.
+func NewOrder(by By) Order {
+	switch by {
+	default:
+		return Unchanged{}
+	}
+}

--- a/backend/app/usecase/search/order/unchanged.go
+++ b/backend/app/usecase/search/order/unchanged.go
@@ -1,0 +1,18 @@
+package order
+
+import "github.com/short-d/short/backend/app/entity"
+
+var _ Order = (*Unchanged)(nil)
+
+// Unchanged represents the Order with unchanged arrangement of searchable resources.
+type Unchanged struct{}
+
+// ArrangeShortLinks keeps the same arrangement of shortLinks.
+func (u Unchanged) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.ShortLink {
+	return shortLinks
+}
+
+// ArrangeShortLinks keeps the same arrangement of users.
+func (u Unchanged) ArrangeUsers(users []entity.User) []entity.User {
+	return users
+}

--- a/backend/app/usecase/search/order/unchanged.go
+++ b/backend/app/usecase/search/order/unchanged.go
@@ -12,7 +12,7 @@ func (u Unchanged) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.Sho
 	return shortLinks
 }
 
-// ArrangeShortLinks keeps the same arrangement of users.
+// ArrangeUsers keeps the same arrangement of users.
 func (u Unchanged) ArrangeUsers(users []entity.User) []entity.User {
 	return users
 }

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -32,7 +32,6 @@ func (s Search) Search(query Query, filter Filter) (Result, error) {
 		orders = append(orders, order.NewOrder(orderBy))
 	}
 
-	// search resources in concurrently
 	for i := range filter.Resources {
 		go func() {
 			result, err := s.searchResource(filter.Resources[i], orders[i], query, filter)

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -1,10 +1,12 @@
 package search
 
 import (
+	"errors"
 	"time"
 
 	"github.com/short-d/short/backend/app/entity"
 	"github.com/short-d/short/backend/app/usecase/repository"
+	"github.com/short-d/short/backend/app/usecase/search/order"
 )
 
 // Search finds different types of resources matching certain criteria and sort them based on predefined orders.
@@ -22,7 +24,68 @@ type Result struct {
 
 // Search finds resources based on specified criteria.
 func (s Search) Search(query Query, filter Filter) (Result, error) {
+	resultCh := make(chan Result)
+	defer close(resultCh)
+
+	var orders []order.Order
+	for _, orderBy := range filter.Orders {
+		orders = append(orders, order.NewOrder(orderBy))
+	}
+
+	// search resources in concurrently
+	for i := range filter.Resources {
+		go func() {
+			result, err := s.searchResource(filter.Resources[i], orders[i], query, filter)
+			if err != nil {
+				resultCh <- Result{}
+				return
+			}
+			resultCh <- result
+		}()
+	}
+
+	timeout := time.After(s.timeout)
+	var results []Result
+	for i := 0; i < len(filter.Resources); i++ {
+		select {
+		case result := <-resultCh:
+			results = append(results, result)
+		case <-timeout:
+			return mergeResults(results), nil
+		}
+	}
+
+	return mergeResults(results), nil
+}
+
+func (s Search) searchResource(resource Resource, orderBy order.Order, query Query, filter Filter) (Result, error) {
+	switch resource {
+	case ShortLink:
+		return s.searchShortLink(query, orderBy, filter)
+	case User:
+		return s.searchUser(query, orderBy, filter)
+	default:
+		return Result{}, errors.New("unknown resource")
+	}
+}
+
+func (s Search) searchShortLink(query Query, orderBy order.Order, filter Filter) (Result, error) {
 	return Result{}, nil
+}
+
+func (s Search) searchUser(query Query, orderBy order.Order, filter Filter) (Result, error) {
+	return Result{}, nil
+}
+
+func mergeResults(results []Result) Result {
+	var mergedResult Result
+
+	for _, result := range results {
+		mergedResult.shortLinks = append(mergedResult.shortLinks, result.shortLinks...)
+		mergedResult.users = append(mergedResult.users, result.users...)
+	}
+
+	return mergedResult
 }
 
 // NewSearch creates Search


### PR DESCRIPTION
Search Short's resources by starting a goroutine for each resource.

This PR is part of [issue #260](https://github.com/short-d/short/issues/260), as the continuation of [#PR 829](https://github.com/short-d/short/pull/829).

The approach used here is very similar to Rob Pike's talk on [Go Concurrency Patterns
Rob Pike](https://talks.golang.org/2012/concurrency.slide#50).