### PR TITLE
Remove redundant code coverage after merged to master branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,7 +69,6 @@ steps:
       branch:
         - master
       event:
-        - push
         - pull_request
 
   - name: run backend unit tests
@@ -149,7 +148,6 @@ steps:
       branch:
         - master
       event:
-        - push
         - pull_request
 
   - name: create testing frontend assets


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Code coverage used to report `failed to find commit` error when we can to force push to master to critical fixes. This forced us to replace Codecov token every time when it happens in order to continuously report code coverage. Forcing report coverage on master alleviated this issue. 

## New Behavior
### Description
Codecov is now much stable. Hence removing this unnecessary reporting to speed up CI build.
