### PR TITLE
Add ByCreatedTimeASC order for Search

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,7 +69,6 @@ steps:
       branch:
         - master
       event:
-        - push
         - pull_request
 
   - name: run backend unit tests
@@ -149,7 +148,6 @@ steps:
       branch:
         - master
       event:
-        - push
         - pull_request
 
   - name: create testing frontend assets

--- a/backend/app/usecase/search/order/created_time.go
+++ b/backend/app/usecase/search/order/created_time.go
@@ -13,6 +13,8 @@ type CreatedTime struct {
 }
 
 // ArrangeShortLinks arranges shortLinks based on CreatedAt.
+// The returned short links satisfies the created before comparision if CreatedAt
+// is not nil, otherwise it sits on the end of the slices if CreatedAt is nil.
 func (c CreatedTime) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.ShortLink {
 	sort.SliceStable(shortLinks, func(i, j int) bool {
 		if shortLinks[j].CreatedAt == nil {
@@ -26,6 +28,8 @@ func (c CreatedTime) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.S
 }
 
 // ArrangeUsers arranges users based on CreatedAt.
+// The returned users satisfies the created before comparision if CreatedAt
+// is not nil, otherwise it sits on the end of the slices if CreatedAt is nil.
 func (c CreatedTime) ArrangeUsers(users []entity.User) []entity.User {
 	sort.SliceStable(users, func(i, j int) bool {
 		if users[j].CreatedAt == nil {

--- a/backend/app/usecase/search/order/created_time.go
+++ b/backend/app/usecase/search/order/created_time.go
@@ -2,42 +2,45 @@ package order
 
 import (
 	"sort"
+	"time"
 
 	"github.com/short-d/short/backend/app/entity"
 )
 
 var _ Order = (*CreatedTime)(nil)
 
-// CreatedTime arranges searchable resources based on their created time.
+// CreatedTime arranges searchable resources based on when they are created.
 type CreatedTime struct {
 }
 
 // ArrangeShortLinks arranges shortLinks based on CreatedAt.
-// The returned short links satisfies the created before comparision if CreatedAt
-// is not nil, otherwise it sits on the end of the slices if CreatedAt is nil.
 func (c CreatedTime) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.ShortLink {
-	sort.SliceStable(shortLinks, func(i, j int) bool {
-		if shortLinks[j].CreatedAt == nil {
-			return true
-		} else if shortLinks[i].CreatedAt == nil {
-			return false
-		}
-		return shortLinks[i].CreatedAt.Before(*shortLinks[j].CreatedAt)
+	sort.SliceStable(shortLinks, func(firstIdx, secondIdx int) bool {
+		return lessTime(shortLinks[firstIdx].CreatedAt, shortLinks[secondIdx].CreatedAt)
 	})
 	return shortLinks
 }
 
 // ArrangeUsers arranges users based on CreatedAt.
-// The returned users satisfies the created before comparision if CreatedAt
-// is not nil, otherwise it sits on the end of the slices if CreatedAt is nil.
 func (c CreatedTime) ArrangeUsers(users []entity.User) []entity.User {
-	sort.SliceStable(users, func(i, j int) bool {
-		if users[j].CreatedAt == nil {
-			return true
-		} else if users[i].CreatedAt == nil {
-			return false
-		}
-		return users[i].CreatedAt.Before(*users[j].CreatedAt)
+	sort.SliceStable(users, func(firstIdx, secondIdx int) bool {
+		return lessTime(users[firstIdx].CreatedAt, users[secondIdx].CreatedAt)
 	})
 	return users
+}
+
+func lessTime(first, second *time.Time) bool {
+	if first == nil && second == nil {
+		return true
+	}
+
+	if first == nil {
+		return false
+	}
+
+	if second == nil {
+		return true
+	}
+
+	return first.Before(*second)
 }

--- a/backend/app/usecase/search/order/created_time.go
+++ b/backend/app/usecase/search/order/created_time.go
@@ -1,0 +1,39 @@
+package order
+
+import (
+	"sort"
+
+	"github.com/short-d/short/backend/app/entity"
+)
+
+var _ Order = (*CreatedTime)(nil)
+
+// CreatedTime arranges searchable resources based on their created time.
+type CreatedTime struct {
+}
+
+// ArrangeShortLinks arranges shortLinks based on CreatedAt.
+func (c CreatedTime) ArrangeShortLinks(shortLinks []entity.ShortLink) []entity.ShortLink {
+	sort.SliceStable(shortLinks, func(i, j int) bool {
+		if shortLinks[j].CreatedAt == nil {
+			return true
+		} else if shortLinks[i].CreatedAt == nil {
+			return false
+		}
+		return shortLinks[i].CreatedAt.Before(*shortLinks[j].CreatedAt)
+	})
+	return shortLinks
+}
+
+// ArrangeUsers arranges users based on CreatedAt.
+func (c CreatedTime) ArrangeUsers(users []entity.User) []entity.User {
+	sort.SliceStable(users, func(i, j int) bool {
+		if users[j].CreatedAt == nil {
+			return true
+		} else if users[i].CreatedAt == nil {
+			return false
+		}
+		return users[i].CreatedAt.Before(*users[j].CreatedAt)
+	})
+	return users
+}

--- a/backend/app/usecase/search/order/created_time_test.go
+++ b/backend/app/usecase/search/order/created_time_test.go
@@ -1,0 +1,181 @@
+package order
+
+import (
+	"testing"
+	"time"
+
+	"github.com/short-d/app/fw/assert"
+	"github.com/short-d/short/backend/app/entity"
+)
+
+func TestCreatedTime_ArrangeShortLinks(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	before := now.Add(-5 * time.Second)
+	after := now.Add(5 * time.Second)
+
+	testCases := []struct {
+		name               string
+		shortLinks         []entity.ShortLink
+		expectedShortLinks []entity.ShortLink
+	}{
+		{
+			name:               "empty short links",
+			shortLinks:         []entity.ShortLink{},
+			expectedShortLinks: []entity.ShortLink{},
+		},
+		{
+			name: "short links without creation time",
+			shortLinks: []entity.ShortLink{
+				{Alias: "short"},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "google"},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "google"},
+				{Alias: "short"},
+			},
+		},
+		{
+			name: "ordered short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+			},
+		},
+		{
+			name: "unordered short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+			},
+		},
+		{
+			name: "tied short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "youtube", CreatedAt: &after},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "youtube", CreatedAt: &after},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderByTime := NewOrder(ByCreatedTimeASC)
+			result := orderByTime.ArrangeShortLinks(testCase.shortLinks)
+
+			assert.Equal(t, testCase.expectedShortLinks, result)
+		})
+	}
+}
+
+func TestCreatedTime_ArrangeShortUsers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	before := now.Add(-5 * time.Second)
+	after := now.Add(5 * time.Second)
+
+	testCases := []struct {
+		name          string
+		users         []entity.User
+		expectedUsers []entity.User
+	}{
+		{
+			name:          "empty users",
+			users:         []entity.User{},
+			expectedUsers: []entity.User{},
+		},
+		{
+			name: "users without creation time",
+			users: []entity.User{
+				{ID: "gamma"},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "alpha"},
+			},
+			expectedUsers: []entity.User{
+				{ID: "beta", CreatedAt: &now},
+				{ID: "alpha"},
+				{ID: "gamma"},
+			},
+		},
+		{
+			name: "ordered users",
+			users: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+			},
+			expectedUsers: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+			},
+		},
+		{
+			name: "unordered users",
+			users: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+			},
+			expectedUsers: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+			},
+		},
+		{
+			name: "tied short links",
+			users: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "delta", CreatedAt: &after},
+			},
+			expectedUsers: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "delta", CreatedAt: &after},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderByTime := NewOrder(ByCreatedTimeASC)
+			result := orderByTime.ArrangeUsers(testCase.users)
+
+			assert.Equal(t, testCase.expectedUsers, result)
+		})
+	}
+}

--- a/backend/app/usecase/search/order/order.go
+++ b/backend/app/usecase/search/order/order.go
@@ -18,6 +18,8 @@ type Order interface {
 // NewOrder creates Order.
 func NewOrder(by By) Order {
 	switch by {
+	case ByCreatedTimeASC:
+		return CreatedTime{}
 	default:
 		return Unchanged{}
 	}

--- a/backend/app/usecase/search/order/unchanged_test.go
+++ b/backend/app/usecase/search/order/unchanged_test.go
@@ -1,0 +1,155 @@
+package order
+
+import (
+	"testing"
+	"time"
+
+	"github.com/short-d/app/fw/assert"
+	"github.com/short-d/short/backend/app/entity"
+)
+
+func TestUnchanged_ArrangeShortLinks(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	before := now.Add(-5 * time.Second)
+	after := now.Add(5 * time.Second)
+
+	testCases := []struct {
+		name               string
+		shortLinks         []entity.ShortLink
+		expectedShortLinks []entity.ShortLink
+	}{
+		{
+			name:               "empty short links",
+			shortLinks:         []entity.ShortLink{},
+			expectedShortLinks: []entity.ShortLink{},
+		},
+		{
+			name: "ordered short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "short", CreatedAt: &after},
+			},
+		},
+		{
+			name: "unordered short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+			},
+		},
+		{
+			name: "tied short links",
+			shortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "youtube", CreatedAt: &after},
+			},
+			expectedShortLinks: []entity.ShortLink{
+				{Alias: "short", CreatedAt: &after},
+				{Alias: "google", CreatedAt: &before},
+				{Alias: "facebook", CreatedAt: &now},
+				{Alias: "youtube", CreatedAt: &after},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			unOrder := NewOrder(9999)
+			result := unOrder.ArrangeShortLinks(testCase.shortLinks)
+
+			assert.Equal(t, testCase.expectedShortLinks, result)
+		})
+	}
+}
+
+func TestUnchangedTime_ArrangeShortUsers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	before := now.Add(-5 * time.Second)
+	after := now.Add(5 * time.Second)
+
+	testCases := []struct {
+		name          string
+		users         []entity.User
+		expectedUsers []entity.User
+	}{
+		{
+			name:          "empty users",
+			users:         []entity.User{},
+			expectedUsers: []entity.User{},
+		},
+		{
+			name: "ordered users",
+			users: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+			},
+			expectedUsers: []entity.User{
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "gamma", CreatedAt: &after},
+			},
+		},
+		{
+			name: "unordered users",
+			users: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+			},
+			expectedUsers: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+			},
+		},
+		{
+			name: "tied short links",
+			users: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "delta", CreatedAt: &after},
+			},
+			expectedUsers: []entity.User{
+				{ID: "gamma", CreatedAt: &after},
+				{ID: "alpha", CreatedAt: &before},
+				{ID: "beta", CreatedAt: &now},
+				{ID: "delta", CreatedAt: &after},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			unOrder := NewOrder(9999)
+			result := unOrder.ArrangeUsers(testCase.users)
+
+			assert.Equal(t, testCase.expectedUsers, result)
+		})
+	}
+}


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The result from the search doesn't have any order option other than Unchanged which is the default option.

## New Behavior
### Description
Add ByCreatedTimeASC option, which sorts the result of the searchable resources based on created time in ascending order. 
Sorry for this rather larger PR, most of it is test cases. Besides the unit test for ByCreatedTimeASC order, in this PR I included the unit tests for Unchanged order which consists of the same test cases, but we can discuss if those tests are not meaningful for Unchanged order.
