### PR TITLE
Add UpdateOpenGraphMetaTags to adapter

### DIFF
--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -38,7 +38,6 @@ WHERE "%s"=$4;`,
 		openGraphTags.ImageURL,
 		alias,
 	)
-
 	if err != nil {
 		return entity.ShortLink{}, err
 	}

--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -18,7 +18,7 @@ type ShortLinkSql struct {
 	db *sql.DB
 }
 
-// UpdateOpenGraphTags updates OpenGraph Meta Tags for a given short_link.
+// UpdateOpenGraphTags updates OpenGraph meta tags for a given short link.
 func (s *ShortLinkSql) UpdateOpenGraphTags(alias string, openGraphTags metatag.OpenGraph) (entity.ShortLink, error) {
 	statement := fmt.Sprintf(`
 UPDATE "%s"

--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -18,7 +18,7 @@ type ShortLinkSql struct {
 	db *sql.DB
 }
 
-// UpdateOGMetaTags updates OpenGraph Meta Tags for a given short_link.
+// UpdateOpenGraphTags updates OpenGraph Meta Tags for a given short_link.
 func (s *ShortLinkSql) UpdateOpenGraphTags(alias string, openGraphTags metatag.OpenGraph) (entity.ShortLink, error) {
 	statement := fmt.Sprintf(`
 UPDATE "%s"

--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -18,8 +18,8 @@ type ShortLinkSql struct {
 	db *sql.DB
 }
 
-// UpdateOGMetaTags updates OpenGraph Meta Tags for given alias in short_link table.
-func (s *ShortLinkSql) UpdateOGMetaTags(alias string, openGraphTags metatag.OpenGraph) (entity.ShortLink, error) {
+// UpdateOGMetaTags updates OpenGraph Meta Tags for a given short_link.
+func (s *ShortLinkSql) UpdateOpenGraphTags(alias string, openGraphTags metatag.OpenGraph) (entity.ShortLink, error) {
 	statement := fmt.Sprintf(`
 UPDATE "%s"
 SET "%s"=$1, "%s"=$2, "%s"=$3

--- a/backend/app/adapter/sqldb/short_link.go
+++ b/backend/app/adapter/sqldb/short_link.go
@@ -18,6 +18,7 @@ type ShortLinkSql struct {
 	db *sql.DB
 }
 
+// UpdateOGMetaTags updates OpenGraph Meta Tags for given alias in short_link table.
 func (s *ShortLinkSql) UpdateOGMetaTags(alias string, openGraphTags metatag.OpenGraph) (entity.ShortLink, error) {
 	statement := fmt.Sprintf(`
 UPDATE "%s"

--- a/backend/app/adapter/sqldb/short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/short_link_integration_test.go
@@ -47,6 +47,102 @@ type shortLinkTableRow struct {
 	twitterImageURL    *string
 }
 
+func TestShortLinkSql_UpdateOGMetaTags(t *testing.T) {
+	title1 := "title1"
+	description1 := "description1"
+	imageURL1 := "url1"
+	title2 := "title2"
+	description2 := "description2"
+	imageURL2 := "url2"
+
+	testCases := []struct {
+		name              string
+		tableRows         []shortLinkTableRow
+		alias             string
+		metaTags          metatag.OpenGraph
+		expectedShortLink entity.ShortLink
+	}{
+		{
+			name: "Update nil meta tags",
+			tableRows: []shortLinkTableRow{
+				{
+					alias:    "220uFicCJj",
+					longLink: "http://www.google.com",
+				},
+			},
+			alias: "220uFicCJj",
+			metaTags: metatag.OpenGraph{
+				Title:       &title1,
+				Description: &description1,
+				ImageURL:    &imageURL1,
+			},
+			expectedShortLink: entity.ShortLink{
+				Alias:    "220uFicCJj",
+				LongLink: "http://www.google.com",
+				OpenGraphTags: metatag.OpenGraph{
+					Title:       &title1,
+					Description: &description1,
+					ImageURL:    &imageURL1,
+				},
+			},
+		},
+		{
+			name: "Update non nil meta tags",
+			tableRows: []shortLinkTableRow{
+				{
+					alias:              "220uFicCJj",
+					longLink:           "http://www.google.com",
+					ogTitle:            &title1,
+					ogDescription:      &description1,
+					ogImageURL:         &imageURL1,
+					twitterTitle:       &title1,
+					twitterDescription: &description1,
+					twitterImageURL:    &imageURL1,
+				},
+			},
+			alias: "220uFicCJj",
+			metaTags: metatag.OpenGraph{
+				Title:       &title2,
+				Description: &description2,
+				ImageURL:    &imageURL2,
+			},
+			expectedShortLink: entity.ShortLink{
+				Alias:    "220uFicCJj",
+				LongLink: "http://www.google.com",
+				OpenGraphTags: metatag.OpenGraph{
+					Title:       &title2,
+					Description: &description2,
+					ImageURL:    &imageURL2,
+				},
+				TwitterTags: metatag.Twitter{
+					Title:       &title1,
+					Description: &description1,
+					ImageURL:    &imageURL1,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dbtest.AccessTestDB(
+				dbConnector,
+				dbMigrationTool,
+				dbMigrationRoot,
+				dbConfig,
+				func(sqlDB *sql.DB) {
+					insertShortLinkTableRows(t, sqlDB, testCase.tableRows)
+
+					shortLinkRepo := sqldb.NewShortLinkSql(sqlDB)
+
+					shortLink, err := shortLinkRepo.UpdateOGMetaTags(testCase.alias, testCase.metaTags)
+					assert.Equal(t, nil, err)
+					assert.Equal(t, testCase.expectedShortLink, shortLink)
+				})
+		})
+	}
+}
+
 func TestShortLinkSql_IsAliasExist(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/backend/app/adapter/sqldb/short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/short_link_integration_test.go
@@ -63,7 +63,7 @@ func TestShortLinkSql_UpdateOGMetaTags(t *testing.T) {
 		expectedShortLink entity.ShortLink
 	}{
 		{
-			name: "Update nil meta tags",
+			name: "Twitter tags not provided",
 			tableRows: []shortLinkTableRow{
 				{
 					alias:    "220uFicCJj",
@@ -87,7 +87,7 @@ func TestShortLinkSql_UpdateOGMetaTags(t *testing.T) {
 			},
 		},
 		{
-			name: "Update non nil meta tags",
+			name: "Twitter tags provided",
 			tableRows: []shortLinkTableRow{
 				{
 					alias:              "220uFicCJj",

--- a/backend/app/adapter/sqldb/short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/short_link_integration_test.go
@@ -135,7 +135,7 @@ func TestShortLinkSql_UpdateOGMetaTags(t *testing.T) {
 
 					shortLinkRepo := sqldb.NewShortLinkSql(sqlDB)
 
-					shortLink, err := shortLinkRepo.UpdateOGMetaTags(testCase.alias, testCase.metaTags)
+					shortLink, err := shortLinkRepo.UpdateOpenGraphTags(testCase.alias, testCase.metaTags)
 					assert.Equal(t, nil, err)
 					assert.Equal(t, testCase.expectedShortLink, shortLink)
 				})


### PR DESCRIPTION
Part of #809 

## New Behavior
### Description
UpdateOGMetaTags sqldb adapter method returns new ShortLink after updating OpenGraph MetaTags.
A corresponding GraphQL mutation API will be created for updating OpenGraph MetaTags for a ShortLink