### PR TITLE
Add HasMapping to sql adapter

### DIFF
--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -63,7 +63,7 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 	return aliases, nil
 }
 
-// IsAliasOwnedByUser verifies if the ShortLink alias belongs to the given user.
+// IsAliasOwnedByUser checks whether a given short link belongs to a user.
 func (u UserShortLinkSQL) IsAliasOwnedByUser(user entity.User, alias string) (bool, error) {
 	statement := fmt.Sprintf(`SELECT FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.TableName,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -65,7 +65,7 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 
 // IsAliasOwnedByUser verifies if the ShortLink alias belongs to the given user.
 func (u UserShortLinkSQL) IsAliasOwnedByUser(user entity.User, alias string) (bool, error) {
-	statement := fmt.Sprintf(`SELECT from "%s" WHERE "%s"=$1 AND "%s"=$2`,
+	statement := fmt.Sprintf(`SELECT FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.TableName,
 		table.UserShortLink.ColumnUserID,
 		table.UserShortLink.ColumnShortLinkAlias,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -63,7 +63,7 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 	return aliases, nil
 }
 
-// HasMapping checks whether a given short link belongs to a user.
+// HasMapping checks whether a given short link is tied to a user.
 func (u UserShortLinkSQL) HasMapping(user entity.User, alias string) (bool, error) {
 	query := fmt.Sprintf(`SELECT "%s" FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.ColumnUserID,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -64,7 +64,7 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 }
 
 // IsAliasOwnedByUser checks whether a given short link belongs to a user.
-func (u UserShortLinkSQL) IsAliasOwnedByUser(user entity.User, alias string) (bool, error) {
+func (u UserShortLinkSQL) HasMapping(user entity.User, alias string) (bool, error) {
 	statement := fmt.Sprintf(`SELECT FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.TableName,
 		table.UserShortLink.ColumnUserID,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -72,7 +72,7 @@ func (u UserShortLinkSQL) HasMapping(user entity.User, alias string) (bool, erro
 		table.UserShortLink.ColumnShortLinkAlias,
 	)
 
-	var id int
+	var id string
 	err := u.db.QueryRow(query, user.ID, alias).Scan(&id)
 	if err == sql.ErrNoRows {
 		return false, nil

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -63,8 +63,8 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 	return aliases, nil
 }
 
-// FindAliasByUser verifies if the ShortLink alias belongs to the given user.
-func (u UserShortLinkSQL) FindAliasByUser(user entity.User, alias string) (bool, error) {
+// IsAliasOwnedByUser verifies if the ShortLink alias belongs to the given user.
+func (u UserShortLinkSQL) IsAliasOwnedByUser(user entity.User, alias string) (bool, error) {
 	statement := fmt.Sprintf(`SELECT from "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.TableName,
 		table.UserShortLink.ColumnUserID,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -65,20 +65,22 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 
 // HasMapping checks whether a given short link belongs to a user.
 func (u UserShortLinkSQL) HasMapping(user entity.User, alias string) (bool, error) {
-	statement := fmt.Sprintf(`SELECT FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
+	query := fmt.Sprintf(`SELECT "%s" FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
+		table.UserShortLink.ColumnUserID,
 		table.UserShortLink.TableName,
 		table.UserShortLink.ColumnUserID,
 		table.UserShortLink.ColumnShortLinkAlias,
 	)
 
-	rows, err := u.db.Query(statement, user.ID, alias)
+	var id int
+	err := u.db.QueryRow(query, user.ID, alias).Scan(&id)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
-	defer rows.Close()
-
-	found := rows.Next()
-	return found, nil
+	return true, nil
 }
 
 // NewUserShortLinkSQL creates UserShortLinkSQL

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -63,7 +63,7 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 	return aliases, nil
 }
 
-// IsAliasOwnedByUser checks whether a given short link belongs to a user.
+// HasMapping checks whether a given short link belongs to a user.
 func (u UserShortLinkSQL) HasMapping(user entity.User, alias string) (bool, error) {
 	statement := fmt.Sprintf(`SELECT FROM "%s" WHERE "%s"=$1 AND "%s"=$2`,
 		table.UserShortLink.TableName,

--- a/backend/app/adapter/sqldb/user_short_link.go
+++ b/backend/app/adapter/sqldb/user_short_link.go
@@ -63,6 +63,24 @@ func (u UserShortLinkSQL) FindAliasesByUser(user entity.User) ([]string, error) 
 	return aliases, nil
 }
 
+// FindAliasByUser verifies if the ShortLink alias belongs to the given user.
+func (u UserShortLinkSQL) FindAliasByUser(user entity.User, alias string) (bool, error) {
+	statement := fmt.Sprintf(`SELECT from "%s" WHERE "%s"=$1 AND "%s"=$2`,
+		table.UserShortLink.TableName,
+		table.UserShortLink.ColumnUserID,
+		table.UserShortLink.ColumnShortLinkAlias,
+	)
+
+	rows, err := u.db.Query(statement, user.ID, alias)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	found := rows.Next()
+	return found, nil
+}
+
 // NewUserShortLinkSQL creates UserShortLinkSQL
 func NewUserShortLinkSQL(db *sql.DB) UserShortLinkSQL {
 	return UserShortLinkSQL{

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -114,7 +114,7 @@ func TestListShortLinkSql_FindAliasesByUser(t *testing.T) {
 	}
 }
 
-func TestListShortLinkSql_IsAliasOwnedByUser(t *testing.T) {
+func TestListShortLinkSql_HasMapping(t *testing.T) {
 	now := mustParseTime(t, "2019-05-01T08:02:16Z")
 	user := entity.User{
 		ID:             "test",

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -116,14 +116,6 @@ func TestListShortLinkSql_FindAliasesByUser(t *testing.T) {
 
 func TestListShortLinkSql_HasMapping(t *testing.T) {
 	now := mustParseTime(t, "2019-05-01T08:02:16Z")
-	user := entity.User{
-		ID:             "test",
-		Name:           "mockedUser",
-		Email:          "test@example.com",
-		LastSignedInAt: &now,
-		CreatedAt:      &now,
-		UpdatedAt:      &now,
-	}
 
 	testCases := []struct {
 		name               string
@@ -132,7 +124,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 		relationTableRows  []userShortLinkTableRow
 		alias              string
 		user               entity.User
-		expectIsFound            bool
+		expectIsFound      bool
 	}{
 		{
 			name: "alias does not exist",
@@ -149,8 +141,15 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 			shortLinkTableRows: []shortLinkTableRow{},
 			relationTableRows:  []userShortLinkTableRow{},
 			alias:              "fizzbuzz",
-			user:               user,
-			isFound:            false,
+			user: {
+				ID:             "test",
+				Name:           "mockedUser",
+				Email:          "test@example.com",
+				LastSignedInAt: &now,
+				CreatedAt:      &now,
+				UpdatedAt:      &now,
+			},
+			expectIsFound: false,
 		},
 		{
 			name: "alias does not belong to the user",
@@ -183,9 +182,16 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 					userID: "test2",
 				},
 			},
-			alias:   "fizzbuzz",
-			user:    user,
-			isFound: false,
+			alias: "fizzbuzz",
+			user: {
+				ID:             "test",
+				Name:           "mockedUser",
+				Email:          "test@example.com",
+				LastSignedInAt: &now,
+				CreatedAt:      &now,
+				UpdatedAt:      &now,
+			},
+			expectIsFound: false,
 		},
 		{
 			name: "alias belongs to the user",
@@ -210,9 +216,16 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 					userID: "test",
 				},
 			},
-			alias:   "fizzbuzz",
-			user:    user,
-			isFound: true,
+			alias: "fizzbuzz",
+			user: {
+				ID:             "test",
+				Name:           "mockedUser",
+				Email:          "test@example.com",
+				LastSignedInAt: &now,
+				CreatedAt:      &now,
+				UpdatedAt:      &now,
+			},
+			expectIsFound: true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -230,7 +243,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 					userShortLinkRepo := sqldb.NewUserShortLinkSQL(sqlDB)
 					result, err := userShortLinkRepo.IsAliasOwnedByUser(testCase.user, testCase.alias)
 					assert.Equal(t, nil, err)
-					assert.Equal(t, testCase.isFound, result)
+					assert.Equal(t, testCase.expectIsFound, result)
 				})
 		})
 	}

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -141,7 +141,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 			shortLinkTableRows: []shortLinkTableRow{},
 			relationTableRows:  []userShortLinkTableRow{},
 			alias:              "fizzbuzz",
-			user: {
+			user: entity.User{
 				ID:             "test",
 				Name:           "mockedUser",
 				Email:          "test@example.com",
@@ -183,7 +183,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 				},
 			},
 			alias: "fizzbuzz",
-			user: {
+			user: entity.User{
 				ID:             "test",
 				Name:           "mockedUser",
 				Email:          "test@example.com",
@@ -217,7 +217,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 				},
 			},
 			alias: "fizzbuzz",
-			user: {
+			user: entity.User{
 				ID:             "test",
 				Name:           "mockedUser",
 				Email:          "test@example.com",
@@ -226,6 +226,33 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 				UpdatedAt:      &now,
 			},
 			expectIsFound: true,
+		},
+		{
+			name: "user does not exist",
+			userTableRows: []userTableRow{
+				{
+					id:           "test",
+					email:        "test@example.com",
+					name:         "mockedUser",
+					lastSignedIn: &now,
+					createdAt:    &now,
+					updatedAt:    &now,
+				},
+			},
+			shortLinkTableRows: []shortLinkTableRow{
+				{
+					alias: "fizzbuzz",
+				},
+			},
+			relationTableRows: []userShortLinkTableRow{
+				{
+					alias:  "fizzbuzz",
+					userID: "test",
+				},
+			},
+			alias:         "fizzbuzz",
+			user:          entity.User{},
+			expectIsFound: false,
 		},
 	}
 	for _, testCase := range testCases {
@@ -241,7 +268,7 @@ func TestListShortLinkSql_HasMapping(t *testing.T) {
 					insertUserShortLinkTableRows(t, sqlDB, testCase.relationTableRows)
 
 					userShortLinkRepo := sqldb.NewUserShortLinkSQL(sqlDB)
-					result, err := userShortLinkRepo.IsAliasOwnedByUser(testCase.user, testCase.alias)
+					result, err := userShortLinkRepo.HasMapping(testCase.user, testCase.alias)
 					assert.Equal(t, nil, err)
 					assert.Equal(t, testCase.expectIsFound, result)
 				})

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -114,6 +114,128 @@ func TestListShortLinkSql_FindAliasesByUser(t *testing.T) {
 	}
 }
 
+func TestListShortLinkSql_FindAliasByUser(t *testing.T) {
+	now := mustParseTime(t, "2019-05-01T08:02:16Z")
+	user := entity.User{
+		ID:             "test",
+		Name:           "mockedUser",
+		Email:          "test@example.com",
+		LastSignedInAt: &now,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+
+	testCases := []struct {
+		name               string
+		userTableRows      []userTableRow
+		shortLinkTableRows []shortLinkTableRow
+		relationTableRows  []userShortLinkTableRow
+		alias              string
+		user               entity.User
+		isFound            bool
+	}{
+		{
+			name: "alias does not exist",
+			userTableRows: []userTableRow{
+				{
+					id:           "test",
+					email:        "test@example.com",
+					name:         "mockedUser",
+					lastSignedIn: &now,
+					createdAt:    &now,
+					updatedAt:    &now,
+				},
+			},
+			shortLinkTableRows: []shortLinkTableRow{},
+			relationTableRows:  []userShortLinkTableRow{},
+			alias:              "fizzbuzz",
+			user:               user,
+			isFound:            false,
+		},
+		{
+			name: "alias does not belong to the user",
+			userTableRows: []userTableRow{
+				{
+					id:           "test",
+					email:        "test@example.com",
+					name:         "mockedUser",
+					lastSignedIn: &now,
+					createdAt:    &now,
+					updatedAt:    &now,
+				},
+				{
+					id:           "test2",
+					email:        "test2@example.com",
+					name:         "mockedUser2",
+					lastSignedIn: &now,
+					createdAt:    &now,
+					updatedAt:    &now,
+				},
+			},
+			shortLinkTableRows: []shortLinkTableRow{
+				{
+					alias: "fizzbuzz",
+				},
+			},
+			relationTableRows: []userShortLinkTableRow{
+				{
+					alias:  "fizzbuzz",
+					userID: "test2",
+				},
+			},
+			alias:   "fizzbuzz",
+			user:    user,
+			isFound: false,
+		},
+		{
+			name: "alias belongs to the user",
+			userTableRows: []userTableRow{
+				{
+					id:           "test",
+					email:        "test@example.com",
+					name:         "mockedUser",
+					lastSignedIn: &now,
+					createdAt:    &now,
+					updatedAt:    &now,
+				},
+			},
+			shortLinkTableRows: []shortLinkTableRow{
+				{
+					alias: "fizzbuzz",
+				},
+			},
+			relationTableRows: []userShortLinkTableRow{
+				{
+					alias:  "fizzbuzz",
+					userID: "test",
+				},
+			},
+			alias:   "fizzbuzz",
+			user:    user,
+			isFound: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			dbtest.AccessTestDB(
+				dbConnector,
+				dbMigrationTool,
+				dbMigrationRoot,
+				dbConfig,
+				func(sqlDB *sql.DB) {
+					insertUserTableRows(t, sqlDB, testCase.userTableRows)
+					insertShortLinkTableRows(t, sqlDB, testCase.shortLinkTableRows)
+					insertUserShortLinkTableRows(t, sqlDB, testCase.relationTableRows)
+
+					userShortLinkRepo := sqldb.NewUserShortLinkSQL(sqlDB)
+					result, err := userShortLinkRepo.FindAliasByUser(testCase.user, testCase.alias)
+					assert.Equal(t, nil, err)
+					assert.Equal(t, testCase.isFound, result)
+				})
+		})
+	}
+}
+
 func insertUserShortLinkTableRows(
 	t *testing.T,
 	sqlDB *sql.DB,

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -132,7 +132,7 @@ func TestListShortLinkSql_IsAliasOwnedByUser(t *testing.T) {
 		relationTableRows  []userShortLinkTableRow
 		alias              string
 		user               entity.User
-		isFound            bool
+		expectIsFound            bool
 	}{
 		{
 			name: "alias does not exist",

--- a/backend/app/adapter/sqldb/user_short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/user_short_link_integration_test.go
@@ -114,7 +114,7 @@ func TestListShortLinkSql_FindAliasesByUser(t *testing.T) {
 	}
 }
 
-func TestListShortLinkSql_FindAliasByUser(t *testing.T) {
+func TestListShortLinkSql_IsAliasOwnedByUser(t *testing.T) {
 	now := mustParseTime(t, "2019-05-01T08:02:16Z")
 	user := entity.User{
 		ID:             "test",
@@ -228,7 +228,7 @@ func TestListShortLinkSql_FindAliasByUser(t *testing.T) {
 					insertUserShortLinkTableRows(t, sqlDB, testCase.relationTableRows)
 
 					userShortLinkRepo := sqldb.NewUserShortLinkSQL(sqlDB)
-					result, err := userShortLinkRepo.FindAliasByUser(testCase.user, testCase.alias)
+					result, err := userShortLinkRepo.IsAliasOwnedByUser(testCase.user, testCase.alias)
 					assert.Equal(t, nil, err)
 					assert.Equal(t, testCase.isFound, result)
 				})


### PR DESCRIPTION
* Add ability to check if an alias exists within the user's short link repo.
* Add integration tests to cover FindAliasByUser

This is the first PR related to #798. It updates the sql adapter so that it can verify if a specific alias is owned by a given user.