### PR TITLE
Remove manual string concatenation for reCaptcha API request body

### DIFF
--- a/backend/app/adapter/recaptcha/recaptcha.go
+++ b/backend/app/adapter/recaptcha/recaptcha.go
@@ -31,7 +31,7 @@ func (r Service) Verify(captchaResponse string) (requester.VerifyResponse, error
 	apiRes := requester.VerifyResponse{}
 	err := r.http.JSON(http.MethodPost, verifyAPI, headers, body.Encode(), &apiRes)
 	if err != nil {
-		return requester.VerifyResponse{}, errors.New("Error validating captcha response")
+		return requester.VerifyResponse{}, errors.New("failed to retrieve reCaptcha API response")
 	}
 	return apiRes, nil
 }

--- a/backend/app/adapter/recaptcha/recaptcha.go
+++ b/backend/app/adapter/recaptcha/recaptcha.go
@@ -1,8 +1,9 @@
 package recaptcha
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
+	"net/url"
 
 	"github.com/short-d/app/fw/webreq"
 	"github.com/short-d/short/backend/app/usecase/requester"
@@ -24,12 +25,13 @@ func (r Service) Verify(captchaResponse string) (requester.VerifyResponse, error
 	headers := map[string]string{
 		"Content-Type": "application/x-www-form-urlencoded",
 	}
-	// TODO(issue#739): Change ReCaptcha API body to a map.
-	body := fmt.Sprintf("secret=%s&response=%s", r.secret, captchaResponse)
+	body := url.Values{}
+	body.Set("secret", r.secret)
+	body.Set("response", captchaResponse)
 	apiRes := requester.VerifyResponse{}
-	err := r.http.JSON(http.MethodPost, verifyAPI, headers, body, &apiRes)
+	err := r.http.JSON(http.MethodPost, verifyAPI, headers, body.Encode(), &apiRes)
 	if err != nil {
-		return requester.VerifyResponse{}, err
+		return requester.VerifyResponse{}, errors.New("Error validating captcha response")
 	}
 	return apiRes, nil
 }

--- a/backend/app/adapter/recaptcha/recaptcha_integration_test.go
+++ b/backend/app/adapter/recaptcha/recaptcha_integration_test.go
@@ -25,7 +25,7 @@ func TestReCaptcha_Verify(t *testing.T) {
 		httpResponse *http.Response
 		httpErr      error
 		expRes       requester.VerifyResponse
-		expErr		 error
+		expectHasErr bool
 	}{
 		{
 			name: "successful request with score = 0.8",
@@ -53,8 +53,7 @@ func TestReCaptcha_Verify(t *testing.T) {
 			name: "request failed with error",
 			httpResponse: nil,
 			httpErr: errors.New("http request failure"),
-			expRes: requester.VerifyResponse{},
-			expErr: errors.New("Error validating captcha response"),
+			expectHasErr: true,
 		},
 	}
 
@@ -81,7 +80,11 @@ func TestReCaptcha_Verify(t *testing.T) {
 			rc := NewService(httpRequest, expSecret)
 			gotRes, err := rc.Verify(expCaptchaResponse)
 
-			assert.Equal(t, testCase.expErr, err)
+			if testCase.expectHasErr {
+				assert.NotEqual(t, nil, err)
+				return
+			}
+			assert.Equal(t, nil, err)
 			assert.Equal(t, testCase.expRes, gotRes)
 		})
 	}

--- a/backend/app/adapter/recaptcha/recaptcha_integration_test.go
+++ b/backend/app/adapter/recaptcha/recaptcha_integration_test.go
@@ -4,6 +4,7 @@ package recaptcha
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -24,6 +25,7 @@ func TestReCaptcha_Verify(t *testing.T) {
 		httpResponse *http.Response
 		httpErr      error
 		expRes       requester.VerifyResponse
+		expErr		 error
 	}{
 		{
 			name: "successful request with score = 0.8",
@@ -46,6 +48,13 @@ func TestReCaptcha_Verify(t *testing.T) {
 				ChallengeTime: "2006-01-02T15:04:05+07:00",
 				Hostname:      "s.time4hacks.com",
 			},
+		},
+		{
+			name: "unsuccessful request produced an error",
+			httpResponse: nil,
+			httpErr: errors.New("Service encountered an error"),
+			expRes: requester.VerifyResponse{},
+			expErr: errors.New("Error validating captcha response"),
 		},
 	}
 
@@ -72,7 +81,7 @@ func TestReCaptcha_Verify(t *testing.T) {
 			rc := NewService(httpRequest, expSecret)
 			gotRes, err := rc.Verify(expCaptchaResponse)
 
-			assert.Equal(t, nil, err)
+			assert.Equal(t, testCase.expErr, err)
 			assert.Equal(t, testCase.expRes, gotRes)
 		})
 	}

--- a/backend/app/adapter/recaptcha/recaptcha_integration_test.go
+++ b/backend/app/adapter/recaptcha/recaptcha_integration_test.go
@@ -50,9 +50,9 @@ func TestReCaptcha_Verify(t *testing.T) {
 			},
 		},
 		{
-			name: "unsuccessful request produced an error",
+			name: "request failed with error",
 			httpResponse: nil,
-			httpErr: errors.New("Service encountered an error"),
+			httpErr: errors.New("http request failure"),
 			expRes: requester.VerifyResponse{},
 			expErr: errors.New("Error validating captcha response"),
 		},


### PR DESCRIPTION
Fixes #739.

Also added a test case for recaptcha error response. This pathway shouldn't normally happen since reCAPTCHA always returns 200 response even when there's an error, but this test case should now increase coverage of recaptcha module from 90% to 100%.
