### PR TITLE
Revert "Remove redundant code coverage after merged to master branch"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,7 @@ steps:
       branch:
         - master
       event:
+        - push
         - pull_request
 
   - name: run backend unit tests
@@ -148,6 +149,7 @@ steps:
       branch:
         - master
       event:
+        - push
         - pull_request
 
   - name: create testing frontend assets


### PR DESCRIPTION
Codecov fails to find the coverage for some commits on master branch. This results in coverage for future commits never get reported. Revert this PR to fix the issue.
Reverts short-d/short#839