### PR TITLE
Remove renaming of net/url package

### DIFF
--- a/backend/app/adapter/routing/handle.go
+++ b/backend/app/adapter/routing/handle.go
@@ -3,7 +3,7 @@ package routing
 import (
 	"encoding/json"
 	"net/http"
-	netURL "net/url"
+	"net/url"
 	"strings"
 
 	"github.com/short-d/app/fw/router"
@@ -22,7 +22,7 @@ func NewLongLink(
 	instrumentationFactory request.InstrumentationFactory,
 	shortLinkRetriever shortlink.Retriever,
 	timer timer.Timer,
-	webFrontendURL netURL.URL,
+	webFrontendURL url.URL,
 ) router.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params router.Params) {
 		alias := params["alias"]
@@ -45,7 +45,7 @@ func NewLongLink(
 	}
 }
 
-func serve404(w http.ResponseWriter, r *http.Request, webFrontendURL netURL.URL) {
+func serve404(w http.ResponseWriter, r *http.Request, webFrontendURL url.URL) {
 	webFrontendURL.Path = "/404"
 	http.Redirect(w, r, webFrontendURL.String(), http.StatusSeeOther)
 }
@@ -69,7 +69,7 @@ func NewSSOSignIn(
 // NewSSOSignInCallback generates Short's authentication token given identity provider's authorization code.
 func NewSSOSignInCallback(
 	singleSignOn sso.SingleSignOn,
-	webFrontendURL netURL.URL,
+	webFrontendURL url.URL,
 ) router.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params router.Params) {
 		code := params["code"]

--- a/backend/app/adapter/routing/route.go
+++ b/backend/app/adapter/routing/route.go
@@ -1,7 +1,7 @@
 package routing
 
 import (
-	netURL "net/url"
+	"net/url"
 
 	"github.com/short-d/app/fw/router"
 	"github.com/short-d/app/fw/timer"
@@ -30,7 +30,7 @@ func NewShort(
 	authenticator authenticator.Authenticator,
 	search search.Search,
 ) []router.Route {
-	frontendURL, err := netURL.Parse(webFrontendURL)
+	frontendURL, err := url.Parse(webFrontendURL)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Back when we had our url package(github.com/short-d/short/backend/app/usecase/url) it collided with net/url package. To avoid collision net/url was renamed to netURL.

## New Behavior
### Description
We should avoid renaming imports except to avoid a name collision and that's why now the netURL doesn't need renaming.
