### PR TITLE
Effectual assignments in Go code and constant comments 

### DIFF
--- a/backend/app/adapter/gqlapi/resolver/query_test.go
+++ b/backend/app/adapter/gqlapi/resolver/query_test.go
@@ -68,6 +68,7 @@ func TestQuery_AuthQuery(t *testing.T) {
 			retrieverFake := shortlink.NewRetrieverPersist(&fakeShortLinkRepo, &fakeUserShortLinkRepo)
 			entryRepo := logger.NewEntryRepoFake()
 			lg, err := logger.NewFake(logger.LogOff, &entryRepo)
+			assert.Equal(t, nil, err)
 
 			keyFetcher := keygen.NewKeyFetcherFake([]keygen.Key{})
 			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)

--- a/backend/app/usecase/search/filter.go
+++ b/backend/app/usecase/search/filter.go
@@ -9,10 +9,12 @@ import (
 // Resource represents a type of searchable objects.
 type Resource uint
 
-// Resource constants represent supported types of resource.
 const (
+	// Unknown represent the resource that is not listed or known.
 	Unknown Resource = iota
+	// ShortLink represents the short link resource.
 	ShortLink
+	// User represent the user resource.
 	User
 )
 

--- a/backend/app/usecase/search/order/order.go
+++ b/backend/app/usecase/search/order/order.go
@@ -5,9 +5,10 @@ import "github.com/short-d/short/backend/app/entity"
 // By represents the order of resources being sorted in.
 type By uint
 
-// By constants represent supported types of order.
 const (
+	// ByUnsorted represent the order type which does not sort the resource.
 	ByUnsorted By = iota
+	// ByCreatedTimeASC represent the order type which sorts resources based on created time.
 	ByCreatedTimeASC
 )
 

--- a/backend/app/usecase/sso/linker_test.go
+++ b/backend/app/usecase/sso/linker_test.go
@@ -60,6 +60,8 @@ func TestLinker_IsAccountLinked(t *testing.T) {
 
 			keyFetcher := keygen.NewKeyFetcherFake([]keygen.Key{})
 			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)
+			assert.Equal(t, nil, err)
+
 			userRepo := repository.NewUserFake([]entity.User{})
 			linkerFactory := NewAccountLinkerFactory(keyGen, &userRepo)
 			ssoMap, err := repository.NewsSSOMapFake(testCase.mappingSSOUserIDs, testCase.mappingUserIDs)
@@ -129,6 +131,8 @@ func TestLinker_CreateAndLinkAccount(t *testing.T) {
 				keygen.Key(testCase.key),
 			})
 			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)
+			assert.Equal(t, nil, err)
+
 			userRepo := repository.NewUserFake(testCase.users)
 			linkerFactory := NewAccountLinkerFactory(keyGen, &userRepo)
 			ssoMap, err := repository.NewsSSOMapFake(testCase.mappingSSOUserIDs, testCase.mappingUserIDs)

--- a/backend/app/usecase/sso/sso_test.go
+++ b/backend/app/usecase/sso/sso_test.go
@@ -108,6 +108,7 @@ func TestSingleSignOn_SignIn(t *testing.T) {
 
 			keyFetcher := keygen.NewKeyFetcherFake(testCase.availableKeys)
 			keyGen, err := keygen.NewKeyGenerator(2, &keyFetcher)
+			assert.Equal(t, nil, err)
 
 			userRepo := repository.NewUserFake(testCase.users)
 			linkerFactory := NewAccountLinkerFactory(keyGen, &userRepo)

--- a/backend/tool/data.go
+++ b/backend/tool/data.go
@@ -41,9 +41,15 @@ SELECT email FROM "user" WHERE id IS NULL LIMIT $1;
 		_, err = d.db.Exec(`
 UPDATE "user" SET id=$1 WHERE email=$2;
 `, key, email)
+		if err != nil {
+			panic(err)
+		}
 		_, err = d.db.Exec(`
 UPDATE "user_url_relation" SET user_id=$1 WHERE user_email=$2;
 `, key, email)
+		if err != nil {
+			panic(err)
+		}
 		count++
 	}
 	d.logger.Info(fmt.Sprintf("Migrated %d accounts.", count))


### PR DESCRIPTION
We have some ineffectual assignments in Go code as reported in [Go Report Card](https://goreportcard.com/report/github.com/short-d/short). It is easy to fix by simply handling the error. I also checked for ineffectual assignments after the fix and there are none.

In the [previous PR](https://github.com/short-d/short/pull/878) I commented on the block of constants but it didn't add much value. I marked and modified them but please feel free to suggest completely different comments for them.