### PR TITLE
Fix bug for concurrent search of resources  

### DIFF
--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -34,6 +34,7 @@ func (s Search) Search(query Query, filter Filter) (Result, error) {
 	orders := toOrders(filter.orders)
 
 	for i := range filter.resources {
+		i := i
 		go func() {
 			result, err := s.searchResource(filter.resources[i], orders[i], query, filter)
 			if err != nil {

--- a/backend/app/usecase/search/search_test.go
+++ b/backend/app/usecase/search/search_test.go
@@ -436,6 +436,90 @@ func TestSearch(t *testing.T) {
 				Users: nil,
 			},
 		},
+		{
+			name: "search more than one resource",
+			shortLinks: shortLinks{
+				"git-google": entity.ShortLink{
+					Alias:    "git-google",
+					LongLink: "http://github.com/google",
+				},
+				"google": entity.ShortLink{
+					Alias:    "google",
+					LongLink: "https://google.com",
+				},
+				"short": entity.ShortLink{
+					Alias:    "short",
+					LongLink: "https://short-d.com",
+				},
+				"facebook": entity.ShortLink{
+					Alias:    "facebook",
+					LongLink: "https://facebook.com",
+				},
+			},
+			Query: Query{
+				Query: "short",
+				User: &entity.User{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+			},
+			maxResults: 2,
+			resources:  []Resource{ShortLink, User, Unknown},
+			orders:     []order.By{order.ByCreatedTimeASC, order.ByUnsorted, order.ByCreatedTimeASC},
+			relationUsers: []entity.User{
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+				{
+					ID:    "beta",
+					Email: "beta@example.com",
+				},
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+			},
+			relationShortLinks: []entity.ShortLink{
+				{
+					Alias:    "git-google",
+					LongLink: "http://github.com/google",
+				},
+				{
+					Alias:    "google",
+					LongLink: "https://google.com",
+				},
+				{
+					Alias:    "google",
+					LongLink: "https://google.com",
+				},
+				{
+					Alias:    "short",
+					LongLink: "https://short-d.com",
+				},
+				{
+					Alias:    "facebook",
+					LongLink: "https://facebook.com",
+				},
+			},
+			expectedResult: Result{
+				ShortLinks: []entity.ShortLink{
+					{
+						Alias:    "short",
+						LongLink: "https://short-d.com",
+					},
+				},
+				Users: nil,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
If we search more than the one resource, it only searches the last resource which creates a concurrency bug. The bug is present because of the overwritten value of the current resource inside the for loop when a new thread is started. This PR fixes this issue.