### PR TITLE
Add documentation for GraphQL apis

### DIFF
--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -15,9 +15,9 @@ type Mutation {
 }
 
 type AuthQuery {
-	ShortLink(alias: String!, expireAfter: Time): ShortLink
+	shortLink(alias: String!, expireAfter: Time): ShortLink
 	changeLog: ChangeLog!
-	ShortLinks: [ShortLink!]!
+	shortLinks: [ShortLink!]!
 }
 
 type ChangeLog {

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -33,14 +33,14 @@ type Mutation {
 	): AuthMutation
 }
 
-"""Authentication protected read APIs"""
+"""Read APIs protected with authentication"""
 type AuthQuery {
-	"""Fetch a short link which still valid at the given expiration time"""
+	"""Fetch a short link that is still valid at the given expiration time"""
 	shortLink(
 		"Alias of the short link"
 		alias: String!,
 
-		"Time at which an existing short link may expire"
+		"Time when an existing short link may expire"
 		expireAfter: Time
 	): ShortLink
 
@@ -56,7 +56,10 @@ type ChangeLog {
 	"""The changes announced to the user"""
   	changes: [Change!]!
 
-	"""The time when the user view the change log"""
+	"""
+	The time when the user views the change log. 
+	It's nil if the user has never viewed the change log before.
+	"""
   	lastViewedAt: Time
 }
 
@@ -71,13 +74,13 @@ type Change {
 	"""The detailed description of the change in markdown format"""
   	summaryMarkdown: String
 
-	"""The time at when the change is announced"""
+	"""The time when the change is announced"""
   	releasedAt: Time!
 }
 
-"""Authentication protected write APIs"""
+"""Write APIs protected authentication"""
 type AuthMutation {
-	"""Create a new short link owned by the user"""
+	"""Create a new short link. The creator is the owner of the short link."""
 	createShortLink(
 		shortLink: ShortLinkInput!,
 
@@ -85,7 +88,7 @@ type AuthMutation {
 		isPublic: Boolean!
 	): ShortLink
 
-	"""Create an existing short link owned by the user"""
+	"""Update an existing short link owned by the user"""
 	updateShortLink(
 		"The current alias of the short link"
 		oldAlias: String!,
@@ -93,7 +96,7 @@ type AuthMutation {
 		shortLink: ShortLinkInput!
 	): ShortLink
 
-	"""Announce a change to the system to the users"""
+	"""Announce a change happened to the system to all users"""
 	createChange(
 		change: ChangeInput!
 	): Change
@@ -110,14 +113,14 @@ type AuthMutation {
 	): Change
 
 	"""
-	Mark the change log is viewed by the given user so that change log modal 
-	won't popup again if there is no new change is announced in the middle.
+	Mark the change log as viewed by the given user so that change log modal 
+	won't popup again if there is no new change announced in the meantime.
 	"""
 	viewChangeLog: Time!
 }
 
 input ShortLinkInput {
-	"""The long link that the short link should redirect to"""
+	"""The long link which the short link redirects to"""
 	longLink: String
 
 	"""The alias of the short link"""
@@ -135,7 +138,7 @@ input ChangeInput {
   	summaryMarkdown: String
 }
 
-"""The short link which redirects to a long link"""
+"""The short link mapped to a long link"""
 type ShortLink {
 	"""The alias of the short link"""
 	alias: String
@@ -148,8 +151,8 @@ type ShortLink {
 }
 
 """
-The time is represented either by an integer unix timestamp or a string in 
-RFC3339 format
+The time is represented either by a unix timestamp (integer/float64)  or a string in 
+RFC3339 format (2019-10-12T07:20:50.52Z).
 """
 scalar Time
 `

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -3,60 +3,153 @@ package gqlapi
 const schema = `
 schema {
 	query: Query
-	mutation: Mutation
+    mutation: Mutation
 }
 
+"""Read APIs for Short"""
 type Query {
-	authQuery(authToken: String): AuthQuery
+	"""
+	Fetch desired attributes of objects from the persistent data store on 
+	behalf of the given user.
+	"""
+	authQuery(
+		"JWT token needed to verify and identify a user"
+		authToken: String
+	): AuthQuery
 }
 
+"""Write APIs for Short"""
 type Mutation {
-	authMutation(authToken: String, captchaResponse: String!): AuthMutation
+	"""
+	Create, update & delete objects from the persistent data store on behalf of 
+	the given user.
+	"""
+	authMutation(
+		"JWT token needed to verify and identify a user"
+		authToken: String,
+
+		"The page interaction patterns needed to verify the requester is human"
+		captchaResponse: String!
+	): AuthMutation
 }
 
+"""Authentication protected read APIs"""
 type AuthQuery {
-	shortLink(alias: String!, expireAfter: Time): ShortLink
+	"""Fetch a short link which still valid at the given expiration time"""
+	shortLink(
+		"Alias of the short link"
+		alias: String!,
+
+		"Time at which an existing short link may expire"
+		expireAfter: Time
+	): ShortLink
+
+	"""Fetch the all the changes visible to the current user"""
 	changeLog: ChangeLog!
+
+	"""Fetch all the short links created by the current user"""
 	shortLinks: [ShortLink!]!
 }
 
+"""A sequence of changes visible to a given user"""
 type ChangeLog {
+	"""The changes announced to the user"""
   	changes: [Change!]!
+
+	"""The time when the user view the change log"""
   	lastViewedAt: Time
 }
 
+"""The announcement for a newly launched feature, a bug fix or a policy change"""
 type Change {
+	"""ID of the change"""
   	id: String!
+
+	"""The title of the change"""
   	title: String!
+
+	"""The detailed description of the change in markdown format"""
   	summaryMarkdown: String
+
+	"""The time at when the change is announced"""
   	releasedAt: Time!
 }
 
+"""Authentication protected write APIs"""
 type AuthMutation {
-	createShortLink(shortLink: ShortLinkInput!, isPublic: Boolean!): ShortLink
-	updateShortLink(oldAlias: String!, shortLink: ShortLinkInput!): ShortLink
-	createChange(change: ChangeInput!): Change
-	deleteChange(id: String!): String
-	updateChange(id: String!, change: ChangeInput!): Change
+	"""Create a new short link owned by the user"""
+	createShortLink(
+		shortLink: ShortLinkInput!,
+
+		"Whether this short link will be visible to all users"
+		isPublic: Boolean!
+	): ShortLink
+
+	"""Create an existing short link owned by the user"""
+	updateShortLink(
+		"The current alias of the short link"
+		oldAlias: String!,
+
+		shortLink: ShortLinkInput!
+	): ShortLink
+
+	"""Announce a change to the system to the users"""
+	createChange(
+		change: ChangeInput!
+	): Change
+
+	"""Delete a change with given ID"""
+	deleteChange(
+		id: String!
+	): String
+
+	"""Update a change with given ID"""
+	updateChange(
+		id: String!, 
+		change: ChangeInput!
+	): Change
+
+	"""
+	Mark the change log is viewed by the given user so that change log modal 
+	won't popup again if there is no new change is announced in the middle.
+	"""
 	viewChangeLog: Time!
 }
 
 input ShortLinkInput {
+	"""The long link that the short link should redirect to"""
 	longLink: String
+
+	"""The alias of the short link"""
 	customAlias: String
+	
+	"""The time when the short link expires"""
 	expireAt: Time
 }
 
 input ChangeInput {
+	"""The title of the change"""
   	title: String!
+
+	"""The detailed description of the change in markdown format"""
   	summaryMarkdown: String
 }
 
+"""The short link which redirects to a long link"""
 type ShortLink {
+	"""The alias of the short link"""
 	alias: String
+	
+	"""The destination of the short link"""
 	longLink: String
+
+	"""The time when the short link expires"""
 	expireAt: Time
 }
 
+"""
+The time is represented either by an integer unix timestamp or a string in 
+RFC3339 format
+"""
 scalar Time
 `

--- a/backend/app/adapter/gqlapi/schema.go
+++ b/backend/app/adapter/gqlapi/schema.go
@@ -3,7 +3,7 @@ package gqlapi
 const schema = `
 schema {
 	query: Query
-    mutation: Mutation
+	mutation: Mutation
 }
 
 """Read APIs for Short"""

--- a/frontend/src/component/ui/Icon.tsx
+++ b/frontend/src/component/ui/Icon.tsx
@@ -120,10 +120,7 @@ export class Icon extends Component<IProps, IStates> {
 
   private renderEditIcon() {
     return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-      >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path d="M0 0h24v24H0z" fill="none" />
         <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
       </svg>
@@ -132,10 +129,7 @@ export class Icon extends Component<IProps, IStates> {
 
   private renderCheckIcon() {
     return (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-      >
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path d="M0 0h24v24H0z" fill="none" />
         <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
       </svg>

--- a/frontend/src/service/shortGraphQL/ShortLinkGraphQL.api.ts
+++ b/frontend/src/service/shortGraphQL/ShortLinkGraphQL.api.ts
@@ -26,7 +26,7 @@ export class ShortLinkGraphQLApi {
     const getUserShortLinksQuery = `
       query params($authToken: String!) {
         authQuery(authToken: $authToken) {
-          ShortLinks {
+          shortLinks {
             alias
             longLink
           }
@@ -41,8 +41,8 @@ export class ShortLinkGraphQLApi {
           variables: variables
         })
         .then((res: IShortGraphQLQuery) => {
-          const { ShortLinks } = res.authQuery;
-          resolve(ShortLinks.map(this.parseUrl));
+          const { shortLinks } = res.authQuery;
+          resolve(shortLinks.map(this.parseUrl));
         })
         .catch((err: IGraphQLRequestError) => {
           const errCodes = getErrorCodes(err);

--- a/frontend/src/service/shortGraphQL/schema.ts
+++ b/frontend/src/service/shortGraphQL/schema.ts
@@ -7,7 +7,7 @@ export interface IShortGraphQLQuery {
 }
 
 export interface IShortGraphQLAuthQuery {
-  ShortLinks: IShortGraphQLShortLink[];
+  shortLinks: IShortGraphQLShortLink[];
   changeLog: IShortGraphQLChangeLog;
 }
 


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The is no documentation for GraphQL APIs. Both internal & external developers are confused how to use them.

## New Behavior
### Description
Add description to the API and the arguments.

### Screenshot
<img width="577" alt="Screen Shot 2020-06-27 at 5 10 44 PM" src="https://user-images.githubusercontent.com/3537801/85934580-3c560980-b899-11ea-8c8a-aa179000c4a7.png">

