### PR TITLE
Center align changelog 'view all updates' button

### DIFF
--- a/frontend/src/component/ui/ChangeLogModal.scss
+++ b/frontend/src/component/ui/ChangeLogModal.scss
@@ -90,6 +90,7 @@
     display: flex;
     box-sizing: border-box;
     padding: 24px;
+    align-items: center;
     justify-content: center;
     box-shadow: $shadow-card;
 


### PR DESCRIPTION
Fixes #857.

## Current Behavior ( Optional for new feature )
### Description
"View All Updates" button in changelog is not vertically aligned.

After some digging, it appears this is due to flexbox layout and a missing property to align it vertically (on cross-axis)

### Screenshots
<img width="733" alt="Screen Shot 2020-06-13 at 6 36 15 PM" src="https://user-images.githubusercontent.com/3537801/84582769-16167100-ada5-11ea-8fd0-bfb322496fe9.png">

## New Behavior
### Description
Using [align-items](https://css-tricks.com/almanac/properties/a/align-items/) CSS property, the flexbox item is appropriately aligned in the cross-axis.

### Screenshots
<img width="516" alt="image" src="https://user-images.githubusercontent.com/3276350/85935321-5b669280-b8bd-11ea-8d63-c1838b2a36db.png">

