### PR TITLE
Handle duplicated alias in Usecase

### DIFF
--- a/backend/app/adapter/gqlapi/api_test.go
+++ b/backend/app/adapter/gqlapi/api_test.go
@@ -3,7 +3,6 @@
 package gqlapi
 
 import (
-	"github.com/short-d/short/backend/app/fw/filesystem"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/short-d/app/fw/timer"
 	"github.com/short-d/short/backend/app/adapter/gqlapi/resolver"
 	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/fw/filesystem"
 	"github.com/short-d/short/backend/app/usecase/authenticator"
 	"github.com/short-d/short/backend/app/usecase/authorizer"
 	"github.com/short-d/short/backend/app/usecase/authorizer/rbac"
@@ -82,6 +82,6 @@ func TestGraphQlAPI(t *testing.T) {
 	schema := "schema.graphql"
 	fileSystem := filesystem.NewLocal()
 	graphqlAPI, err := NewShort(schema, fileSystem, r)
-	assert.Equal(t,nil, err)
+	assert.Equal(t, nil, err)
 	assert.Equal(t, true, graphql.IsGraphQlAPIValid(graphqlAPI))
 }

--- a/backend/app/usecase/shortlink/updater.go
+++ b/backend/app/usecase/shortlink/updater.go
@@ -44,6 +44,14 @@ func (u UpdaterPersist) UpdateShortLink(
 		return entity.ShortLink{}, ErrShortLinkNotFound
 	}
 
+	aliasExist, err := u.shortLinkRepo.IsAliasExist(update.Alias)
+	if err != nil {
+		return entity.ShortLink{}, err
+	}
+	if aliasExist {
+		return entity.ShortLink{}, ErrAliasExist("short link alias already exist")
+	}
+
 	shortLink, err := u.shortLinkRepo.GetShortLinkByAlias(oldAlias)
 	if err != nil {
 		return entity.ShortLink{}, err

--- a/backend/app/usecase/shortlink/updater_test.go
+++ b/backend/app/usecase/shortlink/updater_test.go
@@ -95,6 +95,47 @@ func TestShortLinkUpdaterPersist_UpdateShortLink(t *testing.T) {
 			expectedShortLink: entity.ShortLink{},
 		},
 		{
+			name:  "update alias already exist",
+			alias: "git",
+			shortlinks: shortLinks{
+				"git": entity.ShortLink{
+					Alias:     "git",
+					LongLink:  "https://github.com/short-d",
+					UpdatedAt: &now,
+				},
+				"short-d": entity.ShortLink{
+					Alias:     "short-d",
+					LongLink:  "http://short-d.com/",
+					UpdatedAt: &now,
+				},
+			},
+			user: entity.User{
+				ID:    "1",
+				Email: "gopher@golang.org",
+			},
+			update: entity.ShortLink{
+				Alias: "short-d",
+			},
+			relationUsers: []entity.User{
+				{ID: "1"},
+				{ID: "1"},
+			},
+			relationShortLinks: []entity.ShortLink{
+				{
+					Alias:     "git",
+					LongLink:  "https://github.com/short-d",
+					UpdatedAt: &now,
+				},
+				{
+					Alias:     "short-d",
+					LongLink:  "http://short-d.com/",
+					UpdatedAt: &now,
+				},
+			},
+			expectedHasErr:    true,
+			expectedShortLink: entity.ShortLink{},
+		},
+		{
 			name:  "long link is invalid",
 			alias: "boGp9w35",
 			shortlinks: shortLinks{

--- a/backend/app/usecase/shortlink/updater_test.go
+++ b/backend/app/usecase/shortlink/updater_test.go
@@ -95,7 +95,7 @@ func TestShortLinkUpdaterPersist_UpdateShortLink(t *testing.T) {
 			expectedShortLink: entity.ShortLink{},
 		},
 		{
-			name:  "update alias already exist",
+			name:  "alias already exist",
 			alias: "git",
 			shortlinks: shortLinks{
 				"git": entity.ShortLink{
@@ -133,7 +133,6 @@ func TestShortLinkUpdaterPersist_UpdateShortLink(t *testing.T) {
 				},
 			},
 			expectedHasErr:    true,
-			expectedShortLink: entity.ShortLink{},
 		},
 		{
 			name:  "long link is invalid",


### PR DESCRIPTION
## Current Behavior
### Description
When a user tries to update a short link but the updated short link alias already exists then it fails because of the Postgres database unique on the alias.
### Screenshots
![image](https://user-images.githubusercontent.com/8199285/86283442-5d906000-bbe1-11ea-954d-46325667dcf1.png)

## New Behavior
### Description
Handle error in Usecase, which is independent of storage and more friendly. Before pushing the commit, I ran the format script, which added some changes.
