### PR TITLE
Refactor error type checking to use errors.As

### DIFF
--- a/backend/app/adapter/gqlapi/resolver/authmutation.go
+++ b/backend/app/adapter/gqlapi/resolver/authmutation.go
@@ -93,9 +93,9 @@ func (a AuthMutation) CreateShortLink(args *CreateShortLinkArgs) (*ShortLink, er
 
 	var (
 		ae shortlink.ErrAliasExist
-		l shortlink.ErrInvalidLongLink
-		c shortlink.ErrInvalidCustomAlias
-		m shortlink.ErrMaliciousLongLink
+		l  shortlink.ErrInvalidLongLink
+		c  shortlink.ErrInvalidCustomAlias
+		m  shortlink.ErrMaliciousLongLink
 	)
 	if errors.As(err, &ae) {
 		return nil, ErrAliasExist(*customAlias)
@@ -189,7 +189,7 @@ func (a AuthMutation) DeleteChange(args *DeleteChangeArgs) (*string, error) {
 	}
 
 	var (
-		u changelog.ErrUnauthorizedAction 
+		u changelog.ErrUnauthorizedAction
 	)
 	if errors.As(err, &u) {
 		return nil, ErrUnauthorizedAction(fmt.Sprintf("user %s is not allowed to delete the change %s", user.ID, args.ID))
@@ -222,7 +222,7 @@ func (a AuthMutation) UpdateChange(args *UpdateChangeArgs) (*Change, error) {
 	}
 
 	var (
-		u changelog.ErrUnauthorizedAction 
+		u changelog.ErrUnauthorizedAction
 	)
 	if errors.As(err, &u) {
 		return nil, ErrUnauthorizedAction(fmt.Sprintf("user %s is not allowed to update the change %s", user.ID, args.ID))

--- a/backend/app/adapter/gqlapi/resolver/authmutation.go
+++ b/backend/app/adapter/gqlapi/resolver/authmutation.go
@@ -99,11 +99,14 @@ func (a AuthMutation) CreateShortLink(args *CreateShortLinkArgs) (*ShortLink, er
 	)
 	if errors.As(err, &ae) {
 		return nil, ErrAliasExist(*customAlias)
-	} else if errors.As(err, &l) {
+	}
+	if errors.As(err, &l) {
 		return nil, ErrInvalidLongLink{u.LongLink, string(l.Violation)}
-	} else if errors.As(err, &c) {
+	}
+	if errors.As(err, &c) {
 		return nil, ErrInvalidCustomAlias{*customAlias, string(c.Violation)}
-	} else if errors.As(err, &m) {
+	}
+	if errors.As(err, &m) {
 		return nil, ErrMaliciousContent(u.LongLink)
 	}
 	return nil, ErrUnknown{}

--- a/backend/app/usecase/changelog/changelog.go
+++ b/backend/app/usecase/changelog/changelog.go
@@ -1,6 +1,7 @@
 package changelog
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -85,12 +86,12 @@ func (p Persist) GetLastViewedAt(user entity.User) (*time.Time, error) {
 		return &lastViewedAt, nil
 	}
 
-	// TODO(issue#823): refactor error type checking
-	switch err.(type) {
-	case repository.ErrEntryNotFound:
+	var (
+		e repository.ErrEntryNotFound
+	)
+	if errors.As(err, &e) {
 		return nil, nil
 	}
-
 	return nil, err
 }
 
@@ -102,9 +103,10 @@ func (p Persist) ViewChangeLog(user entity.User) (time.Time, error) {
 		return lastViewedAt, nil
 	}
 
-	// TODO(issue#823): refactor error type checking
-	switch err.(type) {
-	case repository.ErrEntryNotFound:
+	var (
+		e repository.ErrEntryNotFound
+	)
+	if errors.As(err, &e) {
 		err = p.userChangeLogRepo.CreateRelation(user, now)
 		if err != nil {
 			return time.Time{}, err
@@ -112,7 +114,6 @@ func (p Persist) ViewChangeLog(user entity.User) (time.Time, error) {
 
 		return now, nil
 	}
-
 	return time.Time{}, err
 }
 

--- a/backend/app/usecase/shortlink/updater_test.go
+++ b/backend/app/usecase/shortlink/updater_test.go
@@ -132,7 +132,7 @@ func TestShortLinkUpdaterPersist_UpdateShortLink(t *testing.T) {
 					UpdatedAt: &now,
 				},
 			},
-			expectedHasErr:    true,
+			expectedHasErr: true,
 		},
 		{
 			name:  "long link is invalid",


### PR DESCRIPTION
Changed the convention of error type checking to use the new style introduced in Go 1.13, addressing #823.

https://blog.golang.org/go1.13-errors

One of the major benefits of using this style is that `errors.As` (and `errors.Is`) will examine the entire error chain and give you the error if it's within the chain. A drawback is that the syntax looks a bit more verbose than switch statements, but the ability to examine the error chain makes up for it I think!