### PR TITLE
Migrate to CSS module to avoid style leaking

### DIFF
--- a/frontend/src/component/ui/Button.module.scss
+++ b/frontend/src/component/ui/Button.module.scss
@@ -7,8 +7,7 @@
   font-weight: $font-weight-semi-bold;
 
   @include round-corner;
-
-  padding: 0 20px;
+  padding: 5px 20px;
   color: white;
   border: none;
   outline: none;

--- a/frontend/src/component/ui/Button.tsx
+++ b/frontend/src/component/ui/Button.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import './Button.scss';
+import styles from './Button.module.scss';
 
 interface Props {
   onClick?: () => void;
@@ -16,7 +16,7 @@ export class Button extends Component<Props> {
 
   render() {
     return (
-      <button className="button" onClick={this.handleClick}>
+      <button className={styles.button} onClick={this.handleClick}>
         {this.props.children}
       </button>
     );


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Currently, the button component can be accidentally styled in it's parent when css selectors overlap. This results in confusion and unnecessary debugging when things start to break.

## New Behavior
### Description
Switch to css module so that the styles of the button is complete isolated from it's consumers.
