### PR TITLE
Support styling for button

### DIFF
--- a/frontend/src/component/pages/shared/sign-in/FacebookSignInButton.tsx
+++ b/frontend/src/component/pages/shared/sign-in/FacebookSignInButton.tsx
@@ -11,8 +11,8 @@ export class FacebookSignInButton extends Component<IProps> {
   render() {
     return (
       <SignInButton
+        color={'blue'}
         signInLink={this.props.facebookSignInLink}
-        backgroundColor={'#385C8E'}
         oauthProviderIconSrc={facebookLogo}
         oauthProviderName={'Facebook'}
       />

--- a/frontend/src/component/pages/shared/sign-in/GithubSignInButton.tsx
+++ b/frontend/src/component/pages/shared/sign-in/GithubSignInButton.tsx
@@ -11,8 +11,8 @@ export class GithubSignInButton extends Component<IProps> {
   render() {
     return (
       <SignInButton
+        color={'black'}
         signInLink={this.props.githubSignInLink}
-        backgroundColor={'#343434'}
         oauthProviderIconSrc={githubLogo}
         oauthProviderName={'Github'}
       />

--- a/frontend/src/component/pages/shared/sign-in/GoogleSignInButton.tsx
+++ b/frontend/src/component/pages/shared/sign-in/GoogleSignInButton.tsx
@@ -11,8 +11,8 @@ export class GoogleSignInButton extends Component<IProps> {
   render() {
     return (
       <SignInButton
+        color={'red'}
         signInLink={this.props.googleSignInLink}
-        backgroundColor={'#c1423d'}
         oauthProviderIconSrc={googleLogo}
         oauthProviderName={'Google'}
       />

--- a/frontend/src/component/pages/shared/sign-in/SignInButton.scss
+++ b/frontend/src/component/pages/shared/sign-in/SignInButton.scss
@@ -5,22 +5,17 @@
 @import '../../../styles/shadow';
 
 .sign-in-button {
-  .button {
-    @include round-corner;
+  color: inherit;
+  text-decoration: none;
 
-    align-items: center;
-    box-shadow: $shadow-button;
-    color: $color-white;
-    cursor: pointer;
+  .content {
     display: flex;
     font-weight: $font-weight-semi-bold;
     justify-content: center;
+    align-items: center;
     padding: 10px 40px;
-    transition: opacity 100ms $ease-in-out-quart;
-
-    &:hover {
-      opacity: 0.9;
-    }
+    font-family: 'Source Code Pro', 'Helvetica Neue', sans-serif;
+    width: 100%;
 
     .icon {
       fill: $color-white;
@@ -28,10 +23,5 @@
       margin-right: 20px;
       width: 30px;
     }
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
   }
 }

--- a/frontend/src/component/pages/shared/sign-in/SignInButton.tsx
+++ b/frontend/src/component/pages/shared/sign-in/SignInButton.tsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 
+import { Button } from '../../../ui/Button';
+
 import './SignInButton.scss';
 
 interface IProps {
+  color: string;
   signInLink: string;
-  backgroundColor: string;
   oauthProviderIconSrc: string;
   oauthProviderName: string;
 }
@@ -12,14 +14,9 @@ interface IProps {
 export class SignInButton extends Component<IProps> {
   render() {
     return (
-      <div className={'sign-in-button'}>
-        <a href={this.props.signInLink}>
-          <div
-            className={'button'}
-            style={{
-              backgroundColor: this.props.backgroundColor
-            }}
-          >
+      <a href={this.props.signInLink} className={'sign-in-button'}>
+        <Button styles={[this.props.color, 'full-width', 'shadow']}>
+          <div className={'content'}>
             <img
               alt={`Sign in with ${this.props.oauthProviderName} account`}
               className={'icon'}
@@ -27,8 +24,8 @@ export class SignInButton extends Component<IProps> {
             />
             Sign in with {this.props.oauthProviderName}
           </div>
-        </a>
-      </div>
+        </Button>
+      </a>
     );
   }
 }

--- a/frontend/src/component/ui/Button.module.scss
+++ b/frontend/src/component/ui/Button.module.scss
@@ -1,17 +1,44 @@
 @import '../styles/corner';
 @import '../styles/color';
 @import '../styles/font';
+@import '../styles/shadow';
 
 .button {
   font-size: 16px;
   font-weight: $font-weight-semi-bold;
+  display: flex;
+  align-items: center;
 
   @include round-corner;
   padding: 5px 20px;
   color: white;
   border: none;
   outline: none;
-  background-color: $color-primary;
+
+  &.pink {
+    background-color: $color-primary;
+  }
+
+  &.blue {
+    background-color: #385c8e;
+  }
+
+  &.black {
+    background-color: #343434;
+  }
+
+  &.red {
+    background-color: #c1423d;
+  }
+
+  &.full-width {
+    padding: 0;
+    width: 100%;
+  }
+
+  &.shadow {
+    box-shadow: $shadow-button;
+  }
 
   &:hover {
     cursor: pointer;

--- a/frontend/src/component/ui/Button.tsx
+++ b/frontend/src/component/ui/Button.tsx
@@ -1,12 +1,16 @@
 import React, { Component } from 'react';
 
 import styles from './Button.module.scss';
+import { Styling, withCSSModule } from './style';
 
-interface Props {
+interface Props extends Styling {
   onClick?: () => void;
 }
 
 export class Button extends Component<Props> {
+  static defaultProps: Props = {
+    styles: ['pink']
+  };
   handleClick = () => {
     if (!this.props.onClick) {
       return;
@@ -16,7 +20,12 @@ export class Button extends Component<Props> {
 
   render() {
     return (
-      <button className={styles.button} onClick={this.handleClick}>
+      <button
+        className={`${withCSSModule(this.props.styles, styles)} ${
+          styles.button
+        }`}
+        onClick={this.handleClick}
+      >
         {this.props.children}
       </button>
     );

--- a/frontend/src/component/ui/Button.tsx
+++ b/frontend/src/component/ui/Button.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 import styles from './Button.module.scss';
-import { Styling, withCSSModule } from './style';
+import { Styling, withCSSModule } from './styling';
 
 interface Props extends Styling {
   onClick?: () => void;

--- a/frontend/src/component/ui/styling.ts
+++ b/frontend/src/component/ui/styling.ts
@@ -1,0 +1,7 @@
+export interface Styling {
+  styles: string[];
+}
+
+export function withCSSModule(styles: string[], cssModuleStyles: any): string {
+  return styles.map(style => cssModuleStyles[style]).join(' ');
+}


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Sign in button in the sign in modal and the signout button in the header have their own implementation of button. The only difference between them is the look and feel.

## New Behavior
### Description
Allow users to pass styles property in order to customize the button visual appearance of the button. This allows multiple place to use the button while they have different look and feel.
