### PR TITLE
Fix Docker image name

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -371,7 +371,7 @@ steps:
       - docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - docker tag short-frontend:latest $DOCKERHUB_USERNAME/short-frontend:latest
       - docker tag short-backend:latest $DOCKERHUB_USERNAME/short-backend:latest
-      - docker tag short-backend:latest $DOCKERHUB_USERNAME/short-backend:latest
+      - docker tag story:latest $DOCKERHUB_ORG_IDE/story:latest
       - docker push $DOCKERHUB_USERNAME/short-frontend:latest
       - docker push $DOCKERHUB_USERNAME/short-backend:latest
       - docker push $DOCKERHUB_ORG_ID/story:latest


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
Docker image for storybook was never tagged for pushing to Dockerhub.

## New Behavior
### Description
Tagged storybook image with the correct name.
