### PR TITLE
Add storybook for Toggle

### DIFF
--- a/story/src/1-Toggle.stories.tsx
+++ b/story/src/1-Toggle.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Toggle } from '../../frontend/src/component/ui/Toggle';
+import { action } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+
+export default {
+  title: 'UI/Toggle',
+  component: <Toggle />,
+  decorators: [withInfo({ header: false, inline: true })]
+};
+
+export const pink = () => {
+  return <Toggle defaultIsEnabled={false} onClick={action('click')}></Toggle>;
+};


### PR DESCRIPTION
Adds a section in the storybook for `Toggle` component.

![toggle-storybook](https://user-images.githubusercontent.com/3276350/87866623-111f8100-c952-11ea-9b52-b8dd8469d6fe.png)
