### PR TITLE
Added missing port info in the frontend link.

### DIFF
--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -84,7 +84,7 @@ export class UrlService {
   }
 
   aliasToFrontendLink(alias: string): string {
-    return `${window.location.protocol}//${window.location.hostname}/r/${alias}`;
+    return `${window.location.protocol}//${window.location.hostname}:${window.location.port}/r/${alias}`;
   }
 
   aliasToBackendLink(alias: string): string {

--- a/frontend/src/service/Url.service.ts
+++ b/frontend/src/service/Url.service.ts
@@ -84,7 +84,7 @@ export class UrlService {
   }
 
   aliasToFrontendLink(alias: string): string {
-    return `${window.location.protocol}//${window.location.hostname}:${window.location.port}/r/${alias}`;
+    return `${window.location.protocol}//${window.location.host}/r/${alias}`;
   }
 
   aliasToBackendLink(alias: string): string {


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
Port info is missing in the generated frontend link due to which the link is not correct when the port is other than port 80.
### Description

### Screenshots

## New Behavior
Added port info in the generated frontend link.
### Description

### Screenshots
