### PR TITLE
Fix bug not showing created long link

### DIFF
--- a/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
+++ b/frontend/src/component/pages/shared/CreateShortLinkSection.tsx
@@ -160,6 +160,7 @@ export class CreateShortLinkSection extends Component<IProps, IState> {
 
         this.setState({
           createdShortLink: shortLink,
+          createdLongLink: longLink,
           qrCodeURL: qrCodeURL,
           shouldShowUsage: true
         });


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
The confirmation message doesn't show the long link for which the short link was created.
### Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/18581705/87883486-4cd74b00-ca25-11ea-9570-46310b14845c.png">

## New Behavior
### Description
Added the created long link into states which is displayed in the confirmation message
### Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/18581705/87883514-7d1ee980-ca25-11ea-8414-4ccb2838408d.png">
