### PR TITLE
Add implementation for incident and progress (Draft)

### DIFF
--- a/backend/app/adapter/sqldb/incident.go
+++ b/backend/app/adapter/sqldb/incident.go
@@ -1,0 +1,69 @@
+package sqldb
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/short-d/short/backend/app/adapter/sqldb/table"
+	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/usecase/repository"
+)
+
+var _ repository.Incident = (*IncidentSQL)(nil)
+
+type IncidentSQL struct {
+	db *sql.DB
+}
+
+func (i IncidentSQL) GetIncident(incidentID string) (entity.Incident, error) {
+	query := fmt.Sprintf(
+		`SELECT "%s", "%s", "%s" FROM "%s"WHERE "%s"=$1;`,
+		table.Incident.ColumnID,
+		table.Incident.ColumnTitle,
+		table.Incident.ColumnCreatedAt,
+		table.Incident.TableName,
+		table.Incident.ColumnID,
+	)
+	incident := entity.Incident{}
+	err := i.db.QueryRow(query, incidentID).Scan(&incident.ID, &incident.Title, &incident.CreatedAt)
+	if err != nil {
+		return entity.Incident{}, err
+	}
+	incident.CreatedAt = utc(incident.CreatedAt)
+	return incident, nil
+}
+
+func (i IncidentSQL) GetIncidents(after time.Time) ([]entity.Incident, error) {
+	statement := fmt.Sprintf(
+		`SELECT "%s", "%s", "%s" FROM "%s" WHERE "%s">$1;`,
+		table.Incident.ColumnID,
+		table.Incident.ColumnTitle,
+		table.Incident.ColumnCreatedAt,
+		table.Incident.TableName,
+		table.Incident.ColumnCreatedAt,
+	)
+	var incidents []entity.Incident
+
+	rows, err := i.db.Query(statement, after)
+
+	defer rows.Close()
+	if err != nil {
+		return incidents, nil
+	}
+
+	for rows.Next() {
+		incident := entity.Incident{}
+		err := rows.Scan(
+			&incident.ID,
+			&incident.Title,
+			&incident.CreatedAt,
+		)
+		if err != nil {
+			return incidents, err
+		}
+		incident.CreatedAt = utc(incident.CreatedAt)
+		incidents = append(incidents, incident)
+	}
+	return incidents, nil
+}

--- a/backend/app/adapter/sqldb/migration/30_create_progress_table.sql
+++ b/backend/app/adapter/sqldb/migration/30_create_progress_table.sql
@@ -2,7 +2,7 @@
 CREATE TABLE progress (
   incident_id VARCHAR(4) NOT NULL,
   FOREIGN KEY (incident_id) REFERENCES "incident"(id) ON DELETE CASCADE ON UPDATE CASCADE,
-  status CHARACTER VARYING(15) NOT NULL DEFAULT 'reported',
+  status VARCHAR(15) NOT NULL DEFAULT 'reported',
   info TEXT,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/backend/app/adapter/sqldb/progress.go
+++ b/backend/app/adapter/sqldb/progress.go
@@ -1,0 +1,35 @@
+package sqldb
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/short-d/short/backend/app/adapter/sqldb/table"
+	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/usecase/repository"
+)
+
+var _ repository.Progress = (*IncidentSQL)(nil)
+
+type ProgressSQL struct {
+	db *sql.DB
+}
+
+func (p ProgressSQL) GetProgress(progressID string) (entity.Progress, error) {
+	query := fmt.Sprintf(
+		`SELECT "%s", "%s", "%s", "%s" FROM "%s" WHERE "%s"=$1`,
+		table.Progress.ColumnIncidentID,
+		table.Progress.ColumnStatus,
+		table.Progress.ColumnInfo,
+		table.Progress.ColumnCreatedAt,
+		table.Progress.TableName,
+		table.Progress.ColumnIncidentID,
+	)
+	progress := entity.Progress{}
+	err := p.db.QueryRow(query, progress.ID).Scan(&progress.Incident, &progress.Status, &progress.Info, &progress.CreatedAt)
+	if err != nil {
+		return entity.Progress{}, err
+	}
+	progress.CreatedAt = utc(progress.createdAt)
+	return progress, nil
+}

--- a/backend/app/entity/incident.go
+++ b/backend/app/entity/incident.go
@@ -1,0 +1,10 @@
+package entity
+
+import "time"
+
+// Incident represents an incident
+type Incident struct {
+	ID        string
+	Title     string
+	CreatedAt *time.Time
+}

--- a/backend/app/entity/progress.go
+++ b/backend/app/entity/progress.go
@@ -1,0 +1,14 @@
+package entity
+
+import (
+	"time"
+)
+
+// Progress represents an Progress
+type Progress struct {
+	ID        string
+	Incident  *Incident
+	Status    string
+	Info      string
+	CreatedAt *time.Time
+}

--- a/backend/app/usecase/repository/incident.go
+++ b/backend/app/usecase/repository/incident.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/short-d/short/backend/app/entity"
+)
+
+// Incident accesses incidents from storage, such as a database.
+type Incident interface {
+	GetIncident(incidentID string) (entity.Incident, error)
+	GetIncidents(after time.Time) ([]entity.Incident, error)
+}

--- a/backend/app/usecase/repository/incident_fake.go
+++ b/backend/app/usecase/repository/incident_fake.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"github.com/short-d/short/backend/app/entity"
+)
+
+var _ Incident = (*IncidentFake)(nil)
+
+type IncidentFake struct {
+	incidents []entity.Incident
+}
+
+// GetIncident finds an Incident in the incident table given an Incident ID
+func (i IncidentFake) GetIncident(incidentID string) (entity.Incident, error) {
+	for _, incident := range i.incidents {
+		if incident.ID == incidentID {
+			return incident, nil
+		}
+	}
+	return entity.Incident{}, errors.New("incident not found")
+}
+
+// GetIncidents gets all incidents after a given time.
+func (i IncidentFake) GetIncidents(after time.Time) ([]entity.Incident, error) {
+	var incidents []entity.Incident
+	for _, incident := range i.incidents {
+		if incident.CreatedAt.After(after) {
+			incidents = append(incidents, incident)
+		}
+	}
+	return incidents, nil
+}
+
+func NewIncidentFake(incidents []entity.Incident) IncidentFake {
+	return IncidentFake{incidents: incidents}
+}

--- a/backend/app/usecase/repository/progress.go
+++ b/backend/app/usecase/repository/progress.go
@@ -1,0 +1,10 @@
+package repository
+
+import (
+	"github.com/short-d/short/backend/app/entity"
+)
+
+// Progress access progress from a storage, such as a database
+type Progress interface {
+	GetProgress(incidentID string) ([]entity.Progress, error)
+}

--- a/backend/app/usecase/repository/progress_fake.go
+++ b/backend/app/usecase/repository/progress_fake.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"errors"
+
+	"github.com/short-d/short/backend/app/entity"
+)
+
+var _ Progress = (*ProgressFake)(nil)
+
+type ProgressFake struct {
+	progresses []entity.Progress
+}
+
+// GetProgress finds a Progress in the progress table given a Progress ID
+func (p ProgressFake) GetProgress(progressID string) (entity.Progress, error) {
+	for _, progress := range p.progresses {
+		if progress.ID == progressID {
+			return progress, nil
+		}
+	}
+	return entity.Progress{}, errors.New("progress not found")
+}
+
+func NewProcessFake(progresses []entity.Progress) ProgressFake {
+	return ProgressFake{progresses: progress}
+}


### PR DESCRIPTION
## New Behavior
### Description
Fixes #971. Adds the implementation for the Incident and Progress data models
- The `IncidentRepo` will be able to get an Incident based on an incident Id as well as a list of incidents past a certain time given a time.
- The `ProgressRepo` will be able to get progress data based on progress id.
### Screenshots

TODO:

- [ ] Add tests for the implementation.

![image](https://user-images.githubusercontent.com/17193168/88119239-d86beb80-cb8d-11ea-85db-0a47244acaf8.png)

