### PR TITLE
Extend Table component to support resizing and aligning items

### DIFF
--- a/frontend/src/component/ui/Table.tsx
+++ b/frontend/src/component/ui/Table.tsx
@@ -8,7 +8,7 @@ interface IProps {
   rows?: ReactChild[][];
   widths?: string[];
   alignHeaders?: TextAlignProperty[];
-  alignBody?: TextAlignProperty[];
+  alignBodyColumns?: TextAlignProperty[];
   headerFontSize?: string;
 }
 
@@ -49,14 +49,14 @@ export class Table extends Component<IProps> {
   }
 
   private createBodyRow(row: ReactChild[]) {
-    const { widths, alignBody } = this.props;
+    const { widths, alignBodyColumns } = this.props;
     return row.map((cell: ReactChild, cellIndex: number) => {
       return (
         <td
           key={`cell-${cellIndex}`}
           style={{
             width: widths?.[cellIndex],
-            textAlign: alignBody?.[cellIndex]
+            textAlign: alignBodyColumns?.[cellIndex]
           }}
         >
           {cell}

--- a/frontend/src/component/ui/Table.tsx
+++ b/frontend/src/component/ui/Table.tsx
@@ -1,18 +1,20 @@
 import React, { Component, ReactChild } from 'react';
 
 import './Table.scss';
+import { TextAlignProperty } from 'csstype';
 
 interface IProps {
   headers?: ReactChild[];
   rows?: ReactChild[][];
   widths?: string[];
+  alignHeaders?: TextAlignProperty[];
+  alignBody?: TextAlignProperty[];
+  headerFontSize?: string;
 }
 
 export class Table extends Component<IProps> {
-  private createHeaders(
-    headers: ReactChild[] | undefined,
-    widths: string[] | undefined
-  ) {
+  private createHeaders() {
+    const { headers, widths, alignHeaders, headerFontSize } = this.props;
     if (!headers || headers.length === 0) {
       return null;
     }
@@ -22,7 +24,11 @@ export class Table extends Component<IProps> {
           return (
             <th
               key={`cell-${cellIndex}`}
-              style={{ width: widths?.[cellIndex] }}
+              style={{
+                width: widths?.[cellIndex],
+                textAlign: alignHeaders?.[cellIndex],
+                fontSize: headerFontSize
+              }}
             >
               {cell}
             </th>
@@ -32,22 +38,27 @@ export class Table extends Component<IProps> {
     );
   }
 
-  private createBody(
-    rows: ReactChild[][] | undefined,
-    widths: string[] | undefined
-  ) {
+  private createBody() {
+    const { rows } = this.props;
     if (!rows || rows.length === 0) {
       return null;
     }
     return rows.map((row: ReactChild[], rowIndex: number) => {
-      return <tr key={`row-${rowIndex}`}>{this.createBodyRow(row, widths)}</tr>;
+      return <tr key={`row-${rowIndex}`}>{this.createBodyRow(row)}</tr>;
     });
   }
 
-  private createBodyRow(row: ReactChild[], widths: string[] | undefined) {
+  private createBodyRow(row: ReactChild[]) {
+    const { widths, alignBody } = this.props;
     return row.map((cell: ReactChild, cellIndex: number) => {
       return (
-        <td key={`cell-${cellIndex}`} style={{ width: widths?.[cellIndex] }}>
+        <td
+          key={`cell-${cellIndex}`}
+          style={{
+            width: widths?.[cellIndex],
+            textAlign: alignBody?.[cellIndex]
+          }}
+        >
           {cell}
         </td>
       );
@@ -55,13 +66,11 @@ export class Table extends Component<IProps> {
   }
 
   render() {
-    const { headers, rows, widths } = this.props;
-
     return (
       <div className="table-container">
         <table className="table">
-          <thead>{this.createHeaders(headers, widths)}</thead>
-          <tbody>{this.createBody(rows, widths)}</tbody>
+          <thead>{this.createHeaders()}</thead>
+          <tbody>{this.createBody()}</tbody>
         </table>
       </div>
     );


### PR DESCRIPTION
## Current Behavior ( Optional for new feature )
### Description
There is no way when using the table component to change the size of the headers or aligning the items inside the table from the parent component. These two functionalities are highly required and we should support this basic customization in a table.
### Screenshots
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/18581705/88478517-9c0e0600-cf66-11ea-987b-e14dfcba5c27.png">


## New Behavior
### Description
Added support to customize header font size and aligning both header and body data.
### Screenshots
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/18581705/88478520-a7613180-cf66-11ea-967b-ab1afd8ef889.png">
