### PR TITLE
Use ptr.String for test cases that contain strings

### DIFF
--- a/backend/app/adapter/gqlapi/resolver/query_test.go
+++ b/backend/app/adapter/gqlapi/resolver/query_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/short-d/app/fw/logger"
 	"github.com/short-d/app/fw/timer"
 	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/fw/ptr"
 	"github.com/short-d/short/backend/app/usecase/authenticator"
 	"github.com/short-d/short/backend/app/usecase/authorizer"
 	"github.com/short-d/short/backend/app/usecase/authorizer/rbac"
@@ -29,7 +30,6 @@ func TestQuery_AuthQuery(t *testing.T) {
 	}
 	authToken, err := auth.GenerateToken(user)
 	assert.Equal(t, nil, err)
-	randomToken := "random_token"
 
 	testCases := []struct {
 		name      string
@@ -47,7 +47,7 @@ func TestQuery_AuthQuery(t *testing.T) {
 		},
 		{
 			name:      "with invalid auth token",
-			authToken: &randomToken,
+			authToken: ptr.String("random_token"),
 			expHasErr: false,
 		},
 		{

--- a/backend/app/adapter/sqldb/changelog_integration_test.go
+++ b/backend/app/adapter/sqldb/changelog_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/short-d/short/backend/app/adapter/sqldb"
 	"github.com/short-d/short/backend/app/adapter/sqldb/table"
 	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/fw/ptr"
 )
 
 var insertChangeLogRowSQL = fmt.Sprintf(`
@@ -33,9 +34,6 @@ type changeLogTableRow struct {
 }
 
 func TestChangeLogSql_GetChangeLog(t *testing.T) {
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
-
 	testCases := []struct {
 		name              string
 		tableRows         []changeLogTableRow
@@ -47,23 +45,23 @@ func TestChangeLogSql_GetChangeLog(t *testing.T) {
 				{
 					id:              "12346",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				}, {
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 			},
 			expectedChangeLog: []entity.Change{
 				{
 					ID:              "12346",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 			},
 		},
@@ -95,10 +93,6 @@ func TestChangeLogSql_GetChangeLog(t *testing.T) {
 }
 
 func TestChangeLogSql_CreateChange(t *testing.T) {
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
-	summaryMarkdown3 := "summary 3"
-
 	testCases := []struct {
 		name                  string
 		tableRows             []changeLogTableRow
@@ -112,24 +106,24 @@ func TestChangeLogSql_CreateChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "12346",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			change: entity.Change{
 				ID:              "23456",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChangeLogSize: 3,
 			expectedChange: entity.Change{
 				ID:              "23456",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 		}, {
 			name: "create a change with nil summary",
@@ -137,12 +131,12 @@ func TestChangeLogSql_CreateChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "12346",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			change: entity.Change{
@@ -183,8 +177,6 @@ func TestChangeLogSql_CreateChange(t *testing.T) {
 }
 
 func TestChangeLogSql_DeleteChange(t *testing.T) {
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
 
 	testCases := []struct {
 		name                  string
@@ -199,12 +191,12 @@ func TestChangeLogSql_DeleteChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "67890",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			deleteChangeId:        "67890",
@@ -213,7 +205,7 @@ func TestChangeLogSql_DeleteChange(t *testing.T) {
 				{
 					ID:              "12346",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 			},
 		}, {
@@ -222,12 +214,12 @@ func TestChangeLogSql_DeleteChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "67890",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			deleteChangeId:        "34567",
@@ -236,12 +228,12 @@ func TestChangeLogSql_DeleteChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "67890",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 		},
@@ -270,10 +262,6 @@ func TestChangeLogSql_DeleteChange(t *testing.T) {
 }
 
 func TestChangeLogSql_UpdateChange(t *testing.T) {
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
-	summaryMarkdown3 := "summary 3"
-
 	testCases := []struct {
 		name              string
 		tableRows         []changeLogTableRow
@@ -286,29 +274,29 @@ func TestChangeLogSql_UpdateChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "12346",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			change: entity.Change{
 				ID:              "12345",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChangeLog: []entity.Change{
 				{
 					ID:              "12345",
 					Title:           "title 3",
-					SummaryMarkdown: &summaryMarkdown3,
+					SummaryMarkdown: ptr.String("summary 3"),
 				},
 				{
 					ID:              "12346",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 		}, {
@@ -317,29 +305,29 @@ func TestChangeLogSql_UpdateChange(t *testing.T) {
 				{
 					id:              "12345",
 					title:           "title 1",
-					summaryMarkdown: summaryMarkdown1,
+					summaryMarkdown: "summary 1",
 				},
 				{
 					id:              "12346",
 					title:           "title 2",
-					summaryMarkdown: summaryMarkdown2,
+					summaryMarkdown: "summary 2",
 				},
 			},
 			change: entity.Change{
 				ID:              "23456",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChangeLog: []entity.Change{
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "12346",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 		},

--- a/backend/app/usecase/changelog/changelog_test.go
+++ b/backend/app/usecase/changelog/changelog_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/short-d/app/fw/assert"
 	"github.com/short-d/app/fw/timer"
 	"github.com/short-d/short/backend/app/entity"
+	"github.com/short-d/short/backend/app/fw/ptr"
 	"github.com/short-d/short/backend/app/usecase/authorizer"
 	"github.com/short-d/short/backend/app/usecase/authorizer/rbac"
 	"github.com/short-d/short/backend/app/usecase/authorizer/rbac/role"
@@ -20,9 +21,6 @@ func TestPersist_CreateChange(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
-	summaryMarkdown3 := "summary 3"
 	testCases := []struct {
 		name                  string
 		changeLog             []entity.Change
@@ -40,22 +38,22 @@ func TestPersist_CreateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChange: entity.Change{
 				ID:              "test",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 				ReleasedAt:      now,
 			},
 			availableKeys: []keygen.Key{"test"},
@@ -73,17 +71,17 @@ func TestPersist_CreateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChange: entity.Change{},
 			availableKeys:  []keygen.Key{},
@@ -101,17 +99,17 @@ func TestPersist_CreateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			expectedChange: entity.Change{},
 			availableKeys:  []keygen.Key{"12345"},
@@ -129,12 +127,12 @@ func TestPersist_CreateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
@@ -162,17 +160,17 @@ func TestPersist_CreateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			availableKeys: []keygen.Key{"test"},
 			roles: map[string][]role.Role{
@@ -230,8 +228,6 @@ func TestPersist_GetChangeLog(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
 	testCases := []struct {
 		name          string
 		changeLog     []entity.Change
@@ -245,12 +241,12 @@ func TestPersist_GetChangeLog(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			availableKeys: []keygen.Key{},
@@ -452,8 +448,6 @@ func TestPersist_GetAllChanges(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
 	testCases := []struct {
 		name            string
 		changes         []entity.Change
@@ -469,24 +463,24 @@ func TestPersist_GetAllChanges(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			expectedChanges: []entity.Change{
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			availableKeys: []keygen.Key{},
@@ -503,12 +497,12 @@ func TestPersist_GetAllChanges(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			expectedChanges: []entity.Change{},
@@ -561,8 +555,6 @@ func TestPersist_GetAllChanges(t *testing.T) {
 func TestPersist_DeleteChange(t *testing.T) {
 	t.Parallel()
 
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
 	testCases := []struct {
 		name                  string
 		changeLog             []entity.Change
@@ -579,12 +571,12 @@ func TestPersist_DeleteChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			deleteChangeId: "12345",
@@ -592,7 +584,7 @@ func TestPersist_DeleteChange(t *testing.T) {
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			expectedChangeLogSize: 1,
@@ -610,12 +602,12 @@ func TestPersist_DeleteChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			deleteChangeId: "34567",
@@ -623,12 +615,12 @@ func TestPersist_DeleteChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			expectedChangeLogSize: 2,
@@ -646,12 +638,12 @@ func TestPersist_DeleteChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			deleteChangeId:        "12345",
@@ -708,9 +700,6 @@ func TestPersist_DeleteChange(t *testing.T) {
 func TestPersist_UpdateChange(t *testing.T) {
 	t.Parallel()
 
-	summaryMarkdown1 := "summary 1"
-	summaryMarkdown2 := "summary 2"
-	summaryMarkdown3 := "summary 3"
 	testCases := []struct {
 		name              string
 		changeLog         []entity.Change
@@ -726,18 +715,18 @@ func TestPersist_UpdateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				ID:              "54321",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			roles: map[string][]role.Role{
 				"alpha": {role.Admin},
@@ -749,12 +738,12 @@ func TestPersist_UpdateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 3",
-					SummaryMarkdown: &summaryMarkdown3,
+					SummaryMarkdown: ptr.String("summary 3"),
 				},
 			},
 			hasErr: false,
@@ -765,18 +754,18 @@ func TestPersist_UpdateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				ID:              "34567",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			roles: map[string][]role.Role{
 				"alpha": {role.Admin},
@@ -788,12 +777,12 @@ func TestPersist_UpdateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			hasErr: false,
@@ -804,18 +793,18 @@ func TestPersist_UpdateChange(t *testing.T) {
 				{
 					ID:              "12345",
 					Title:           "title 1",
-					SummaryMarkdown: &summaryMarkdown1,
+					SummaryMarkdown: ptr.String("summary 1"),
 				},
 				{
 					ID:              "54321",
 					Title:           "title 2",
-					SummaryMarkdown: &summaryMarkdown2,
+					SummaryMarkdown: ptr.String("summary 2"),
 				},
 			},
 			change: entity.Change{
 				ID:              "54321",
 				Title:           "title 3",
-				SummaryMarkdown: &summaryMarkdown3,
+				SummaryMarkdown: ptr.String("summary 3"),
 			},
 			roles: map[string][]role.Role{
 				"alpha": {role.Basic},

--- a/backend/app/usecase/shortlink/metatag_test.go
+++ b/backend/app/usecase/shortlink/metatag_test.go
@@ -8,27 +8,12 @@ import (
 	"github.com/short-d/app/fw/assert"
 	"github.com/short-d/short/backend/app/entity"
 	"github.com/short-d/short/backend/app/entity/metatag"
+	"github.com/short-d/short/backend/app/fw/ptr"
 	"github.com/short-d/short/backend/app/usecase/repository"
 )
 
 func TestMetaTagPersist_GetOpenGraphTags(t *testing.T) {
 	t.Parallel()
-
-	title1 := "title1"
-	description1 := "description1"
-	imageURL1 := "imageURL1"
-
-	title2 := "title2"
-	description2 := "description2"
-	imageURL2 := "imageURL2"
-
-	title3 := "title3"
-	description3 := "description3"
-	imageURL3 := "imageURL3"
-
-	defaultTitle := defaultTitle
-	defaultDesc := defaultDesc
-	defaultImageURL := defaultImageURL
 
 	testCases := []struct {
 		name                  string
@@ -44,36 +29,36 @@ func TestMetaTagPersist_GetOpenGraphTags(t *testing.T) {
 					Alias:    "12345",
 					LongLink: "www.google.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title1,
-						Description: &description1,
-						ImageURL:    &imageURL1,
+						Title:       ptr.String("title1"),
+						Description: ptr.String("description1"),
+						ImageURL:    ptr.String("imageURL1"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 				},
 				"54321": entity.ShortLink{
 					Alias:    "54321",
 					LongLink: "www.facebook.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title3,
-						Description: &description3,
-						ImageURL:    &imageURL3,
+						Title:       ptr.String("title3"),
+						Description: ptr.String("description3"),
+						ImageURL:    ptr.String("imageURL3"),
 					},
 				},
 			},
 			alias: "54321",
 			expectedOpenGraphTags: metatag.OpenGraph{
-				Title:       &title2,
-				Description: &description2,
-				ImageURL:    &imageURL2,
+				Title:       ptr.String("title2"),
+				Description: ptr.String("description2"),
+				ImageURL:    ptr.String("imageURL2"),
 			},
 		},
 		{
@@ -84,31 +69,31 @@ func TestMetaTagPersist_GetOpenGraphTags(t *testing.T) {
 					Alias:    "12345",
 					LongLink: "www.google.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title1,
-						Description: &description1,
-						ImageURL:    &imageURL1,
+						Title:       ptr.String("title1"),
+						Description: ptr.String("description1"),
+						ImageURL:    ptr.String("imageURL1"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 				},
 				"54321": entity.ShortLink{
 					Alias:    "54321",
 					LongLink: "www.facebook.com",
 					TwitterTags: metatag.Twitter{
-						Title:       &title3,
-						Description: &description3,
-						ImageURL:    &imageURL3,
+						Title:       ptr.String("title3"),
+						Description: ptr.String("description3"),
+						ImageURL:    ptr.String("imageURL3"),
 					},
 				},
 			},
 			alias: "54321",
 			expectedOpenGraphTags: metatag.OpenGraph{
-				Title:       &defaultTitle,
-				Description: &defaultDesc,
-				ImageURL:    &defaultImageURL,
+				Title:       ptr.String(defaultTitle),
+				Description: ptr.String(defaultDesc),
+				ImageURL:    ptr.String(defaultImageURL),
 			},
 		},
 		{
@@ -143,22 +128,6 @@ func TestMetaTagPersist_GetOpenGraphTags(t *testing.T) {
 func TestMetaTagPersist_GetTwitterTags(t *testing.T) {
 	t.Parallel()
 
-	title1 := "title1"
-	description1 := "description1"
-	imageURL1 := "imageURL1"
-
-	title2 := "title2"
-	description2 := "description2"
-	imageURL2 := "imageURL2"
-
-	title3 := "title3"
-	description3 := "description3"
-	imageURL3 := "imageURL3"
-
-	defaultTitle := defaultTitle
-	defaultDesc := defaultDesc
-	defaultImageURL := defaultImageURL
-
 	testCases := []struct {
 		name                string
 		shortLinks          shortLinks
@@ -173,36 +142,36 @@ func TestMetaTagPersist_GetTwitterTags(t *testing.T) {
 					Alias:    "12345",
 					LongLink: "www.google.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title1,
-						Description: &description1,
-						ImageURL:    &imageURL1,
+						Title:       ptr.String("title1"),
+						Description: ptr.String("description1"),
+						ImageURL:    ptr.String("imageURL1"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 				},
 				"54321": entity.ShortLink{
 					Alias:    "54321",
 					LongLink: "www.facebook.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title3,
-						Description: &description3,
-						ImageURL:    &imageURL3,
+						Title:       ptr.String("title3"),
+						Description: ptr.String("description3"),
+						ImageURL:    ptr.String("imageURL3"),
 					},
 				},
 			},
 			alias: "54321",
 			expectedTwitterTags: metatag.Twitter{
-				Title:       &title3,
-				Description: &description3,
-				ImageURL:    &imageURL3,
+				Title:       ptr.String("title3"),
+				Description: ptr.String("description3"),
+				ImageURL:    ptr.String("imageURL3"),
 			},
 		},
 		{
@@ -212,31 +181,31 @@ func TestMetaTagPersist_GetTwitterTags(t *testing.T) {
 					Alias:    "12345",
 					LongLink: "www.google.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title1,
-						Description: &description1,
-						ImageURL:    &imageURL1,
+						Title:       ptr.String("title1"),
+						Description: ptr.String("description1"),
+						ImageURL:    ptr.String("imageURL1"),
 					},
 					TwitterTags: metatag.Twitter{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 				},
 				"54321": entity.ShortLink{
 					Alias:    "54321",
 					LongLink: "www.facebook.com",
 					OpenGraphTags: metatag.OpenGraph{
-						Title:       &title2,
-						Description: &description2,
-						ImageURL:    &imageURL2,
+						Title:       ptr.String("title2"),
+						Description: ptr.String("description2"),
+						ImageURL:    ptr.String("imageURL2"),
 					},
 				},
 			},
 			alias: "54321",
 			expectedTwitterTags: metatag.Twitter{
-				Title:       &defaultTitle,
-				Description: &defaultDesc,
-				ImageURL:    &defaultImageURL,
+				Title:       ptr.String(defaultTitle),
+				Description: ptr.String(defaultDesc),
+				ImageURL:    ptr.String(defaultImageURL),
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #959. Use `ptr.String()` to allow for direct embedding of strings into tests.