### PR TITLE
Emit errors through Search API

### DIFF
--- a/backend/app/adapter/routing/api.yml
+++ b/backend/app/adapter/routing/api.yml
@@ -117,6 +117,28 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/User'
+        '401':
+          description: unauthorized user
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+        '404':
+          description: unknown resource
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
       security:
         - web_api: []
   /oauth/github/sign-in:

--- a/backend/app/adapter/routing/handle/search.go
+++ b/backend/app/adapter/routing/handle/search.go
@@ -168,7 +168,7 @@ func (f *Filter) resourcesString() []string {
 	return resources
 }
 
-func newSearchResponse(result search.Result) SearchResponse {
+func newSearchResponse(result search.ResourceResult) SearchResponse {
 	shortLinks := make([]ShortLink, len(result.ShortLinks))
 	for i := 0; i < len(result.ShortLinks); i++ {
 		shortLinks[i] = newShortLink(result.ShortLinks[i])

--- a/backend/app/adapter/routing/handle/search.go
+++ b/backend/app/adapter/routing/handle/search.go
@@ -174,7 +174,7 @@ func (f *Filter) resourcesString() []string {
 	return resources
 }
 
-func newSearchResponse(result search.ResourceResult) SearchResponse {
+func newSearchResponse(result search.Result) SearchResponse {
 	shortLinks := make([]ShortLink, len(result.ShortLinks))
 	for i := 0; i < len(result.ShortLinks); i++ {
 		shortLinks[i] = newShortLink(result.ShortLinks[i])

--- a/backend/app/adapter/routing/handle/search.go
+++ b/backend/app/adapter/routing/handle/search.go
@@ -213,8 +213,8 @@ func newUser(user entity.User) User {
 }
 
 func emitSearchError(w http.ResponseWriter, err error) {
-	var code = http.StatusInternalServerError
 	var (
+	       code http.StatusInternalServerError
 		u search.ErrUserNotProvided
 		r search.ErrUnknownResource
 	)

--- a/backend/app/adapter/routing/handle/search.go
+++ b/backend/app/adapter/routing/handle/search.go
@@ -214,9 +214,9 @@ func newUser(user entity.User) User {
 
 func emitSearchError(w http.ResponseWriter, err error) {
 	var (
-	       code http.StatusInternalServerError
-		u search.ErrUserNotProvided
-		r search.ErrUnknownResource
+		code = http.StatusInternalServerError
+		u    search.ErrUserNotProvided
+		r    search.ErrUnknownResource
 	)
 	if errors.As(err, &u) {
 		code = http.StatusUnauthorized

--- a/backend/app/adapter/routing/handle/search.go
+++ b/backend/app/adapter/routing/handle/search.go
@@ -2,6 +2,7 @@ package handle
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -47,6 +48,11 @@ type SearchResponse struct {
 	Users      []User      `json:"users,omitempty"`
 }
 
+// SearchError represents an error with the Search API request.
+type SearchError struct {
+	Message string `json:"message"`
+}
+
 // ShortLink represents the short_link field of Search API respond.
 type ShortLink struct {
 	Alias     string     `json:"alias,omitempty"`
@@ -79,7 +85,7 @@ func Search(
 		defer r.Body.Close()
 		if err != nil {
 			i.SearchFailed(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			emitSearchError(w, err)
 			return
 		}
 
@@ -87,7 +93,7 @@ func Search(
 		err = json.Unmarshal(buf, &body)
 		if err != nil {
 			i.SearchFailed(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			emitSearchError(w, err)
 			return
 		}
 
@@ -99,14 +105,14 @@ func Search(
 		filter, err := search.NewFilter(body.Filter.MaxResults, body.Filter.Resources, body.Filter.Orders)
 		if err != nil {
 			i.SearchFailed(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			emitSearchError(w, err)
 			return
 		}
 
 		results, err := searcher.Search(query, filter)
 		if err != nil {
 			i.SearchFailed(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			emitSearchError(w, err)
 			return
 		}
 
@@ -114,7 +120,7 @@ func Search(
 		respBody, err := json.Marshal(&response)
 		if err != nil {
 			i.SearchFailed(err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			emitSearchError(w, err)
 			return
 		}
 
@@ -204,4 +210,25 @@ func newUser(user entity.User) User {
 		CreatedAt:      user.CreatedAt,
 		UpdatedAt:      user.UpdatedAt,
 	}
+}
+
+func emitSearchError(w http.ResponseWriter, err error) {
+	var code = http.StatusInternalServerError
+	var (
+		u search.ErrUserNotProvided
+		r search.ErrUnknownResource
+	)
+	if errors.As(err, &u) {
+		code = http.StatusUnauthorized
+	}
+	if errors.As(err, &r) {
+		code = http.StatusNotFound
+	}
+	errResp, err := json.Marshal(SearchError{
+		Message: err.Error(),
+	})
+	if err != nil {
+		return
+	}
+	http.Error(w, string(errResp), code)
 }

--- a/backend/app/adapter/sqldb/short_link_integration_test.go
+++ b/backend/app/adapter/sqldb/short_link_integration_test.go
@@ -726,10 +726,10 @@ func TestShortLinkSql_DeleteShortLink(t *testing.T) {
 			name: "delete exisiting shortlink",
 			tableRows: []shortLinkTableRow{
 				{
-					alias:              "short_is_great",
-					longLink:           "https://short-d.com",
-					createdAt:          ptr.Time(must.Time(t, "2018-05-01T08:02:16-07:00")),
-					expireAt:           ptr.Time(must.Time(t, "2020-05-01T08:02:16-07:00")),
+					alias:     "short_is_great",
+					longLink:  "https://short-d.com",
+					createdAt: ptr.Time(must.Time(t, "2018-05-01T08:02:16-07:00")),
+					expireAt:  ptr.Time(must.Time(t, "2020-05-01T08:02:16-07:00")),
 				},
 			},
 			alias:  "short_is_great",
@@ -739,10 +739,10 @@ func TestShortLinkSql_DeleteShortLink(t *testing.T) {
 			name: "shortlink does not exist",
 			tableRows: []shortLinkTableRow{
 				{
-					alias:              "i_luv_short",
-					longLink:           "https://short-d.com",
-					createdAt:          ptr.Time(must.Time(t, "2018-05-01T08:02:16-07:00")),
-					expireAt:           ptr.Time(must.Time(t, "2020-05-01T08:02:16-07:00")),
+					alias:     "i_luv_short",
+					longLink:  "https://short-d.com",
+					createdAt: ptr.Time(must.Time(t, "2018-05-01T08:02:16-07:00")),
+					expireAt:  ptr.Time(must.Time(t, "2020-05-01T08:02:16-07:00")),
 				},
 			},
 			alias:  "short_is_great",

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -66,7 +66,7 @@ func (s Search) Search(query Query, filter Filter) (ResourceResult, error) {
 			}
 			resultCh <- Result{
 				Resources: result,
-				Err: nil,
+				Err:       nil,
 			}
 		}()
 	}

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -32,10 +32,10 @@ type ResourceResult struct {
 }
 
 // ErrUnknownResource represents unknown search resource error.
-type ErrUnknownResource string
+type ErrUnknownResource struct{}
 
 func (e ErrUnknownResource) Error() string {
-	return string(e)
+	return "unknown resource"
 }
 
 // ErrUserNotProvided represents user not provided for search query.
@@ -97,16 +97,14 @@ func (s Search) searchResource(resource Resource, orderBy order.Order, query Que
 	case User:
 		return s.searchUser(query, orderBy, filter)
 	default:
-		// TODO add tests for unknown resource
-		return ResourceResult{}, ErrUnknownResource("unknown resource")
+		return ResourceResult{}, ErrUnknownResource{}
 	}
 }
 
 // TODO(issue#866): Simplify searchShortLink function
 func (s Search) searchShortLink(query Query, orderBy order.Order, filter Filter) (ResourceResult, error) {
 	if query.User == nil {
-		// TODO add a test for user not provided
-		err := ErrUserNotProvided("user not provided")
+		err := ErrUserNotProvided{}
 		s.logger.Error(err)
 		return ResourceResult{}, err
 	}

--- a/backend/app/usecase/search/search.go
+++ b/backend/app/usecase/search/search.go
@@ -39,10 +39,10 @@ func (e ErrUnknownResource) Error() string {
 }
 
 // ErrUserNotProvided represents user not provided for search query.
-type ErrUserNotProvided string
+type ErrUserNotProvided struct{}
 
 func (e ErrUserNotProvided) Error() string {
-	return string(e)
+	return "user not provided"
 }
 
 // Search finds resources based on specified criteria.

--- a/backend/app/usecase/search/search_test.go
+++ b/backend/app/usecase/search/search_test.go
@@ -25,7 +25,7 @@ func TestSearch(t *testing.T) {
 		orders             []order.By
 		relationUsers      []entity.User
 		relationShortLinks []entity.ShortLink
-		expectedResult     Result
+		expectedResult     ResourceResult
 	}{
 		{
 			name: "search without user",
@@ -97,7 +97,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{},
+			expectedResult: ResourceResult{},
 		},
 		{
 			name: "search without query",
@@ -172,7 +172,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{
+			expectedResult: ResourceResult{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "facebook",
@@ -259,7 +259,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{
+			expectedResult: ResourceResult{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "google",
@@ -347,7 +347,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{
+			expectedResult: ResourceResult{
 				ShortLinks: nil,
 				Users:      nil,
 			},
@@ -426,7 +426,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{
+			expectedResult: ResourceResult{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "short",
@@ -510,7 +510,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: Result{
+			expectedResult: ResourceResult{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "short",

--- a/backend/app/usecase/search/search_test.go
+++ b/backend/app/usecase/search/search_test.go
@@ -30,18 +30,33 @@ func TestSearch(t *testing.T) {
 		expHasErr bool
 	}{
 		{
-			name:       "search without user",
-			shortLinks: shortLinks{},
+			name: "search without user",
+			shortLinks: shortLinks{
+				"short": entity.ShortLink{
+					Alias:    "short",
+					LongLink: "https://short-d.com",
+				},
+			},
 			Query: Query{
 				Query: "http google",
 			},
-			maxResults:         2,
-			resources:          []Resource{ShortLink},
-			orders:             []order.By{order.ByCreatedTimeASC},
-			relationUsers:      []entity.User{},
-			relationShortLinks: []entity.ShortLink{},
-			expectedResult:     ResourceResult{},
-			expHasErr:          true,
+			maxResults: 1,
+			resources:  []Resource{ShortLink},
+			orders:     []order.By{order.ByCreatedTimeASC},
+			relationUsers: []entity.User{
+				{
+					ID:    "alpha",
+					Email: "alpha@example.com",
+				},
+			},
+			relationShortLinks: []entity.ShortLink{
+				{
+					Alias:    "short",
+					LongLink: "https://short-d.com",
+				},
+			},
+			expectedResult: ResourceResult{},
+			expHasErr:      true,
 		},
 		{
 			name: "search without query",

--- a/backend/app/usecase/search/search_test.go
+++ b/backend/app/usecase/search/search_test.go
@@ -25,7 +25,7 @@ func TestSearch(t *testing.T) {
 		orders             []order.By
 		relationUsers      []entity.User
 		relationShortLinks []entity.ShortLink
-		expectedResult     ResourceResult
+		expectedResult     Result
 		// TODO(issue#803): Check error types in tests.
 		expHasErr bool
 	}{
@@ -55,7 +55,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://short-d.com",
 				},
 			},
-			expectedResult: ResourceResult{},
+			expectedResult: Result{},
 			expHasErr:      true,
 		},
 		{
@@ -131,7 +131,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: ResourceResult{
+			expectedResult: Result{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "facebook",
@@ -218,7 +218,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: ResourceResult{
+			expectedResult: Result{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "google",
@@ -306,7 +306,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: ResourceResult{
+			expectedResult: Result{
 				//ShortLinks: nil,
 				//Users:      nil,
 			},
@@ -385,7 +385,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: ResourceResult{
+			expectedResult: Result{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "short",
@@ -469,7 +469,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://facebook.com",
 				},
 			},
-			expectedResult: ResourceResult{
+			expectedResult: Result{
 				ShortLinks: []entity.ShortLink{
 					{
 						Alias:    "short",
@@ -509,7 +509,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://short-d.com",
 				},
 			},
-			expectedResult: ResourceResult{},
+			expectedResult: Result{},
 			expHasErr:      true,
 		},
 		{
@@ -542,7 +542,7 @@ func TestSearch(t *testing.T) {
 					LongLink: "https://short-d.com",
 				},
 			},
-			expectedResult: ResourceResult{},
+			expectedResult: Result{},
 			expHasErr:      true,
 		},
 	}


### PR DESCRIPTION
Fixes #865 

Tests not added yet, so this will be in draft until they're added.

Emit errors through search API and add new types for unknown resource and user not provided.

TODO
- [x] Add test for user not provided
- [x] Add tests for unknown resource
  - [x] one unknown resource
  - [x] ~two unknown resources~ edit: redundant, other two cover it
  - [x] one unknown resource and one known resource
- [x] Decide whether errors should be emitted as text or as JSON
- [x] Decide whether to fix two warnings reported by GoLand in `handle/search.go` (edit: going to skip them, beyond the scope of this PR imo)