### PR TITLE
Remove addon-info from Icon story

### DIFF
--- a/story/src/2-Icon.stories.tsx
+++ b/story/src/2-Icon.stories.tsx
@@ -1,73 +1,73 @@
 import React from 'react';
 import { Icon, IconID } from '../../frontend/src/component/ui/Icon';
 import { action } from '@storybook/addon-actions';
-import { withInfo } from '@storybook/addon-info';
-import styles from './2-Icon.stories.module.scss'
+
+import styles from './2-Icon.stories.module.scss';
+
 export default {
   title: 'UI/Icon',
-  component: Icon,
-  decorators: [withInfo({ header: false, inline: true })]
-}
+  component: Icon
+};
 
 export const menu = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Menu} onClick={action('click')}/>
+      <Icon iconID={IconID.Menu} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const menuOpen = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.MenuOpen} onClick={action('click')}/>
+      <Icon iconID={IconID.MenuOpen} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const close = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Close} onClick={action('click')}/>
+      <Icon iconID={IconID.Close} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const search = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Search} onClick={action('click')}/>
+      <Icon iconID={IconID.Search} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const edit = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Edit} onClick={action('click')}/>
+      <Icon iconID={IconID.Edit} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 export const check = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Check} onClick={action('click')}/>
+      <Icon iconID={IconID.Check} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const deleteItem = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.Delete} onClick={action('click')}/>
+      <Icon iconID={IconID.Delete} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};
 
 export const rightArrow = () => {
   return (
     <div className={styles.icon}>
-      <Icon iconID={IconID.RightArrow} onClick={action('click')}/>
+      <Icon iconID={IconID.RightArrow} onClick={action('click')} />
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
Unfortunately missed this from my review of #1002. I removed `addon-info` in PR #996 because it's now deprecated, and because of this change, the Icon story failed once it merged to `master`. This PR removes `addon-info` from the story and also did a bit of auto-formatting.